### PR TITLE
Trust DOM count when removing nodes, not our internal line count

### DIFF
--- a/Classes/Views/Log/LogController.m
+++ b/Classes/Views/Log/LogController.m
@@ -357,6 +357,7 @@
 {
 	needsLimitNumberOfLines = NO;
 	
+	// guess how many lines need to be removed based on our internal counter
 	NSInteger n = count - maxLines;
 	if (!loaded || n <= 0 || count <= 0) return;
 	
@@ -365,6 +366,8 @@
 	DOMHTMLElement* body = (DOMHTMLElement *)[self body:doc];
 	DOMNodeList* nodeList = [body childNodes];
 	
+	// determine exactly how many lines need to be removed via the DOM
+	n = nodeList.length - maxLines;
 	for (NSInteger i=n-1; i>=0; --i) {
 		[body removeChild:[nodeList item:i]];
 	}


### PR DESCRIPTION
Commit message explains.  

My theme adds a timestamp "line" every 5 minutes... (instead including it on each line) Textual gets confused because it doesn't expect themes to add additional lines/nodes.  As far as I can tell this solution doesn't add any real overhead yet allows themes like mine to work - as well as preventing accidental memory/node leaks in other themes in the future.
