### PR TITLE
Don't insert a space to a outgoing IRC command unless there is something to seperate with a space

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -2194,7 +2194,10 @@ static NSDateFormatter *dateTimeFormatter = nil;
 				[s insertString:@":" atIndex:0];
 			}
 			
-			[s insertString:@" " atIndex:0];
+			if ([s length]) {
+				[s insertString:@" " atIndex:0];
+			}
+			
 			[s insertString:cmd atIndex:0];
 			
 			[self sendLine:s];


### PR DESCRIPTION
This was breaking a IRCd which was checking for a command, since there was a space appended to this, the comparison failed.
