### PR TITLE
Simplified Light style CSS colour number 19 correction and adjustment

### DIFF
--- a/Resources/Styles/Simplified Light/design.css
+++ b/Resources/Styles/Simplified Light/design.css
@@ -343,9 +343,9 @@ body .inline_nickname[colornumber='18'] {
 	color: #CC66CC;
 }
 
-body .sender[type=normal][colornumber='18'], 
-body .inline_nickname[colornumber='18'] { 
-	color: #CC66CC;
+body .sender[type=normal][colornumber='19'], 
+body .inline_nickname[colornumber='19'] { 
+	color: #8F478E;
 }
 
 body .sender[type=normal][colornumber='20'], 


### PR DESCRIPTION
Very simple correction change to Simplified Light style. Adjusted correction of definition number 19 from 18, and gave it a similar yet darker colour: #8F478E.
