### PR TITLE
Fix for bundles not loading from ~/Library

### DIFF
--- a/Classes/Helpers/NSBundleHelper.m
+++ b/Classes/Helpers/NSBundleHelper.m
@@ -103,7 +103,7 @@
 	
 	for (NSString *file in resourceFiles) {
 		if ([file hasSuffix:@".bundle"]) {
-			NSString *fullPath	 = [path_2 stringByAppendingPathComponent:file];
+			NSString *fullPath	 = [path_1 stringByAppendingPathComponent:file];
             
             if ([_NSFileManager() fileExistsAtPath:fullPath] == NO) {
                 fullPath = [path_2 stringByAppendingPathComponent:file];


### PR DESCRIPTION
Fixed issue where the loader was testing path_2 twice instead of checking both path_1 and path_2. This made it impossible to load custom bundles from ~/Library
