### PR TITLE
Fix Proxy authentication

### DIFF
--- a/Classes/IRC/IRCConnection.m
+++ b/Classes/IRC/IRCConnection.m
@@ -86,6 +86,7 @@
 	conn.proxyHost = proxyHost;
 	conn.proxyPort = proxyPort;
 	conn.proxyUser = proxyUser;
+	conn.proxyPassword = proxyPassword;
 	
 	[conn open];
 }


### PR DESCRIPTION
This fix injects the proxy password when connecting. This fixes the connection to SOCKS proxy. WFM when using ctrlproxy as a SOCKS proxy.
