### PR TITLE
Strip mode prefix chars for nick completion.

### DIFF
--- a/Classes/Controllers/MasterController.m
+++ b/Classes/Controllers/MasterController.m
@@ -902,8 +902,8 @@
 		NSMutableArray *lowerNicks = [NSMutableArray array];
 		
 		for (IRCUser *m in users) {
-			[nicks      safeAddObject:m.nick];
-			[lowerNicks safeAddObject:[m.nick lowercaseString]];
+			[nicks      safeAddObject:[self stripModePrefix: m.nick]];
+			[lowerNicks safeAddObject:[self stripModePrefix: [m.nick lowercaseString]]];
 		}
 		
 		[nicks      safeAddObject:@"NickServ"];
@@ -1001,6 +1001,19 @@
 		status.text = text.stringValue;
 		status.range = selectedRange;
 	}
+}
+
+- (NSString *)stripModePrefix:(NSString *)nick
+{
+    if ([nick characterAtIndex:0] != '@' && [nick characterAtIndex:0] != '+') {
+        return nick; // shortcut if nick ain't op or voice
+    }
+    NSRange firstCharRange;
+    firstCharRange.location = 0;
+    firstCharRange.length = 1;
+    NSMutableString* newNick = [[NSMutableString alloc] initWithString:nick];
+    [newNick deleteCharactersInRange:firstCharRange];
+    return newNick;
 }
 
 #pragma mark -

--- a/Classes/Headers/MasterController.h
+++ b/Classes/Headers/MasterController.h
@@ -98,4 +98,5 @@
 - (void)selectPreviousUnreadChannel:(NSEvent *)e;
 - (void)selectPreviousActiveChannel:(NSEvent *)e;
 
+- (NSString *)stripModePrefix:(NSString *)nick;
 @end


### PR DESCRIPTION
Nick names with +o or +v get a "@" or "+" character prefixed
in the user list. Nick tab-completion requires the extra char
to be typed for the completion to match, resulting in IRC-
unusual nick+mode-char conversations.

This patch removes a leading @ or + from each nick in the
user list prior to matching for nick completion.

I don't know if this is the best way to do this, but it works :)
