### PR TITLE
Added a simple check for the current dal.net nickserv notices

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -3576,7 +3576,8 @@ static NSDateFormatter *dateTimeFormatter = nil;
                         if ([Preferences autojoinWaitForNickServ]) {
                             if ([text hasPrefix:@"You are now identified"] ||
                                 [text hasPrefix:@"You are already identified"] ||
-                                [text hasSuffix:@"you are now recognized."]) {
+                                [text hasSuffix:@"you are now recognized."] || 
+                                [text hasPrefix:@"Password accepted for"]) {
                                 
                                 if (autojoinInitialized == NO && serverHasNickServ) {
                                     autojoinInitialized = YES;


### PR DESCRIPTION
Add nickserv check for dal.net message and nickserv format (/nickserv is also legit)

I have not looked to see if a connection object has the concept of nick authentication.  If so, that is where the real fix should go.  ie, this notice checking should be a fallback, but popular networks could be coded to just do it properly on the get go vs. expecting to see responses, etc.  Also maybe add some logic to release/ghost nicks for the user.  This is useful for when switching to a VPN or something, that really confuses networks as they end up getting multiple connections for one use as the user switches networks.
