### PR TITLE
Set the target for the member list to the menu

### DIFF
--- a/Classes/Controllers/MasterController.m
+++ b/Classes/Controllers/MasterController.m
@@ -157,6 +157,7 @@
 	menu.text		= text;
 	menu.master		= self;
 	
+	[memberList setTarget:menu];    
 	[memberList setDoubleAction:@selector(memberListDoubleClicked:)];
 	
 	growl = [GrowlController new];


### PR DESCRIPTION
This fixes a bug where the double click action is not dispatched because
te target was not set. So when you double click on a nickname nothing
would happen.
