### PR TITLE
CODE_SIGN_IDENTITY and correct compiler modes for Blowfish

### DIFF
--- a/Textual.xcodeproj/project.pbxproj
+++ b/Textual.xcodeproj/project.pbxproj
@@ -1869,7 +1869,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\ncd \"$PROJECT_DIR/Resources/Plugins/BlowfishCommandLine\"\nxcodebuild -alltargets -configuration \"$CONFIGURATION\" NATIVE_ARCH=\"$NATIVE_ARCH\" FRAMEWORK_SEARCH_PATHS=\"$PROJECT_DIR/Frameworks/**\" HEADER_SEARCH_PATHS=\"$PROJECT_DIR/Classes/Headers/**\" BUNDLE_LOADER=\"$CODESIGNING_FOLDER_PATH/Contents/MacOS/$EXECUTABLE_NAME\" 2> /dev/null\n\ncd \"$PROJECT_DIR/Resources/Plugins/BragSpam\"\nxcodebuild -alltargets -configuration \"$CONFIGURATION\" NATIVE_ARCH=\"$NATIVE_ARCH\" FRAMEWORK_SEARCH_PATHS=\"$PROJECT_DIR/Frameworks/**\" HEADER_SEARCH_PATHS=\"$PROJECT_DIR/Classes/Headers/**\" BUNDLE_LOADER=\"$CODESIGNING_FOLDER_PATH/Contents/MacOS/$EXECUTABLE_NAME\" 2> /dev/null\n\ncd \"$PROJECT_DIR/Resources/Plugins/SystemProfiler\"\nxcodebuild -alltargets -configuration \"$CONFIGURATION\" NATIVE_ARCH=\"$NATIVE_ARCH\" FRAMEWORK_SEARCH_PATHS=\"$PROJECT_DIR/Frameworks/**\" HEADER_SEARCH_PATHS=\"$PROJECT_DIR/Classes/Headers/**\" BUNDLE_LOADER=\"$CODESIGNING_FOLDER_PATH/Contents/MacOS/$EXECUTABLE_NAME\" 2> /dev/null\n";
+			shellScript = "\ncd \"$PROJECT_DIR/Resources/Plugins/BlowfishCommandLine\"\nxcodebuild -alltargets -configuration \"$CONFIGURATION\" NATIVE_ARCH=\"$NATIVE_ARCH\" FRAMEWORK_SEARCH_PATHS=\"$PROJECT_DIR/Frameworks/**\" HEADER_SEARCH_PATHS=\"$PROJECT_DIR/Classes/Headers/**\" BUNDLE_LOADER=\"$CODESIGNING_FOLDER_PATH/Contents/MacOS/$EXECUTABLE_NAME\" CODE_SIGN_IDENTITY=\"$CODE_SIGN_IDENTITY\" 2> /dev/null\n\ncd \"$PROJECT_DIR/Resources/Plugins/BragSpam\"\nxcodebuild -alltargets -configuration \"$CONFIGURATION\" NATIVE_ARCH=\"$NATIVE_ARCH\" FRAMEWORK_SEARCH_PATHS=\"$PROJECT_DIR/Frameworks/**\" HEADER_SEARCH_PATHS=\"$PROJECT_DIR/Classes/Headers/**\" BUNDLE_LOADER=\"$CODESIGNING_FOLDER_PATH/Contents/MacOS/$EXECUTABLE_NAME\" CODE_SIGN_IDENTITY=\"$CODE_SIGN_IDENTITY\" 2> /dev/null\n\ncd \"$PROJECT_DIR/Resources/Plugins/SystemProfiler\"\nxcodebuild -alltargets -configuration \"$CONFIGURATION\" NATIVE_ARCH=\"$NATIVE_ARCH\" FRAMEWORK_SEARCH_PATHS=\"$PROJECT_DIR/Frameworks/**\" HEADER_SEARCH_PATHS=\"$PROJECT_DIR/Classes/Headers/**\" BUNDLE_LOADER=\"$CODESIGNING_FOLDER_PATH/Contents/MacOS/$EXECUTABLE_NAME\" CODE_SIGN_IDENTITY=\"$CODE_SIGN_IDENTITY\" 2> /dev/null\n";
 		};
 		4C627E6714F5BB0500CB2D7B /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1895,7 +1895,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\ncd \"$PROJECT_DIR/Frameworks/Adium/AutoHyperlinks/Source/\"\nxcodebuild -alltargets -configuration \"Release\" NATIVE_ARCH=\"$NATIVE_ARCH\" 2> /dev/null\n\ncd \"$PROJECT_DIR/Frameworks/Blowfish/Source/\"\nxcodebuild -alltargets -configuration \"Release\" NATIVE_ARCH=\"$NATIVE_ARCH\" 2> /dev/null\n";
+			shellScript = "\ncd \"$PROJECT_DIR/Frameworks/Adium/AutoHyperlinks/Source/\"\nxcodebuild -alltargets -configuration \"Release\" NATIVE_ARCH=\"$NATIVE_ARCH\" CODE_SIGN_IDENTITY=\"$CODE_SIGN_IDENTITY\" 2> /dev/null\n\ncd \"$PROJECT_DIR/Frameworks/Blowfish/Source/\"\nxcodebuild -alltargets -configuration \"Release\" NATIVE_ARCH=\"$NATIVE_ARCH\" CODE_SIGN_IDENTITY=\"$CODE_SIGN_IDENTITY\" OTHER_CFLAGS=\"$OTHER_CFLAGS\" 2> /dev/null\n";
 		};
 		4C9CB1CC12AD549E00F107FC /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2277,6 +2277,7 @@
 				GENERATE_PKGINFO_FILE = YES;
 				INFOPLIST_FILE = Resources/Miscellaneous/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				OTHER_CFLAGS = "-std=c99";
 				OTHER_LDFLAGS = (
 					"-framework",
 					Foundation,
@@ -2375,6 +2376,7 @@
 				GENERATE_PKGINFO_FILE = YES;
 				INFOPLIST_FILE = Resources/Miscellaneous/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				OTHER_CFLAGS = "-std=c99";
 				OTHER_LDFLAGS = (
 					"-framework",
 					Foundation,
@@ -2421,6 +2423,7 @@
 				GENERATE_PKGINFO_FILE = YES;
 				INFOPLIST_FILE = Resources/Miscellaneous/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				OTHER_CFLAGS = "-std=c99";
 				OTHER_LDFLAGS = (
 					"-framework",
 					Foundation,
@@ -2494,6 +2497,7 @@
 				GENERATE_PKGINFO_FILE = YES;
 				INFOPLIST_FILE = Resources/Miscellaneous/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				OTHER_CFLAGS = "-std=c99";
 				OTHER_LDFLAGS = (
 					"-framework",
 					Foundation,
@@ -2527,6 +2531,7 @@
 				GENERATE_PKGINFO_FILE = YES;
 				INFOPLIST_FILE = Resources/Miscellaneous/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				OTHER_CFLAGS = "-std=c99";
 				OTHER_LDFLAGS = (
 					"-framework",
 					Foundation,


### PR DESCRIPTION
Added CODE_SIGN_IDENTITY variables to dependent/external builds. Set OTHER_CFLAGS to "-std=c99" to prevent issues with the Blowfish module.

This fixes issue Codeux/Textual#174
