### PR TITLE
disabling unread counts 

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -3166,7 +3166,7 @@ static NSDateFormatter *dateTimeFormatter = nil;
 		}
 	}
 	
-    if (isActiveWindow == NO || (NSDissimilarObjects(world.selected, t) && isActiveWindow)) {
+    if ((NSDissimilarObjects(world.selected, t) && isActiveWindow)) {
 		[t setTreeUnreadCount:([t treeUnreadCount] + 1)];
 	}
 	


### PR DESCRIPTION
This is just a temporary hack until I figured this whole thing out.

For now I just disabled the check to prevent the unread count from being added. It distracted me too much.

I'll love some direction on this. Would the preferred way be to add a new option? Should it be a global option or a per channel setting option? 
