### PR TITLE
Lower TXMaximumIRCBodyLength

### DIFF
--- a/Classes/Headers/IRC.h
+++ b/Classes/Headers/IRC.h
@@ -37,7 +37,7 @@
 
 #import "TextualApplication.h"
 
-#define TXMaximumIRCBodyLength				520
+#define TXMaximumIRCBodyLength				512
 #define TXMaximumNodesPerModeCommand		4
 
 /* Historically, we used a few dozen "IRCCommandIndex<command>" defines to match


### PR DESCRIPTION
"IRC messages are always lines of characters terminated with a CR-LF
   (Carriage Return - Line Feed) pair, and these messages shall not
   exceed 512 characters in length, counting all characters including
   the trailing CR-LF."
