### PR TITLE
Fix graphics card query

### DIFF
--- a/Resources/Plugins/System Profiler/System Profiler Extension.xcodeproj/project.pbxproj
+++ b/Resources/Plugins/System Profiler/System Profiler Extension.xcodeproj/project.pbxproj
@@ -10,10 +10,10 @@
 		4C1BE0FA159A5FCF00DB3341 /* TPISystemProfiler.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4C1BE0F8159A5FCF00DB3341 /* TPISystemProfiler.xib */; };
 		4C57A681131D378900252759 /* TPI_SP_SysInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C57A67E131D378900252759 /* TPI_SP_SysInfo.m */; };
 		4C57A682131D378900252759 /* TPISystemProfiler.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C57A680131D378900252759 /* TPISystemProfiler.m */; };
-		4C57A695131D37F000252759 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C57A694131D37F000252759 /* OpenGL.framework */; };
 		4C8884B0158EB9CE00747ABB /* PLWeakCompatibilityStubs.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C8884AE158EB9CE00747ABB /* PLWeakCompatibilityStubs.m */; };
 		4CD69D82131E2BD200F4618E /* MacintoshModels.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4CD69D81131E2BD200F4618E /* MacintoshModels.plist */; };
 		4CEE0DD112E09A1900C5096E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CEE0DD012E09A1900C5096E /* Cocoa.framework */; };
+		63EF581515D2D5FE001071C8 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63EF581215D2D57F001071C8 /* IOKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,10 +24,10 @@
 		4C57A67E131D378900252759 /* TPI_SP_SysInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPI_SP_SysInfo.m; sourceTree = "<group>"; };
 		4C57A67F131D378900252759 /* TPISystemProfiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TPISystemProfiler.h; sourceTree = "<group>"; };
 		4C57A680131D378900252759 /* TPISystemProfiler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TPISystemProfiler.m; sourceTree = "<group>"; };
-		4C57A694131D37F000252759 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
 		4C8884AE158EB9CE00747ABB /* PLWeakCompatibilityStubs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PLWeakCompatibilityStubs.m; sourceTree = "<group>"; };
 		4CD69D81131E2BD200F4618E /* MacintoshModels.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = MacintoshModels.plist; sourceTree = "<group>"; };
 		4CEE0DD012E09A1900C5096E /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		63EF581215D2D57F001071C8 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = /System/Library/Frameworks/IOKit.framework; sourceTree = "<absolute>"; };
 		8D576316048677EA00EA77CD /* SystemProfiler.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SystemProfiler.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D576317048677EA00EA77CD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -38,7 +38,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4CEE0DD112E09A1900C5096E /* Cocoa.framework in Frameworks */,
-				4C57A695131D37F000252759 /* OpenGL.framework in Frameworks */,
+				63EF581515D2D5FE001071C8 /* IOKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,9 +59,9 @@
 		089C1671FE841209C02AAC07 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				63EF581215D2D57F001071C8 /* IOKit.framework */,
 				4CEE0DD012E09A1900C5096E /* Cocoa.framework */,
 				0AA1909FFE8422F4C02AAC07 /* CoreFoundation.framework */,
-				4C57A694131D37F000252759 /* OpenGL.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Resources/Plugins/System Profiler/SystemProfiler.h
+++ b/Resources/Plugins/System Profiler/SystemProfiler.h
@@ -1,5 +1,4 @@
-#import <OpenGL/OpenGL.h>
-#import <OpenGL/gl.h>
+#import <IOKit/IOKitLib.h>
 
 #import "TextualApplication.h"
 


### PR DESCRIPTION
I changed the GPU query code to use IOKit rather than OpenGL, since this is more accurate (lists all cards) and doesn't trip up GPU switching. I basically followed the information and example code at http://webcache.googleusercontent.com/search?q=cache:pPCE_VfrU-8J:www.starcoder.com/wordpress/2011/10/using-iokit-to-detect-graphics-hardware/+graphics+card+iokit&cd=1&hl=en&ct=clnk&gl=us / http://www.starcoder.com/wordpress/2011/10/using-iokit-to-detect-graphics-hardware/ to do this.
