### PR TITLE
Fix /sysinfo truncation

### DIFF
--- a/Resources/Plugins/System Profiler/TPI_SP_SysInfo.m
+++ b/Resources/Plugins/System Profiler/TPI_SP_SysInfo.m
@@ -508,7 +508,7 @@
             const void *model = CFDictionaryGetValue(serviceDictionary, @"model");
 			
             if (PointerIsNotEmpty(model)) {
-                if (CFGetTypeID(model) == CFDataGetTypeID()) {
+                if (CFGetTypeID(model) == CFDataGetTypeID() && CFDataGetLength(model) > 1) {
 					NSString *s = [NSString stringWithBytes:[(__bridge NSData *)model bytes] length:(CFDataGetLength(model)-1)
                                                    encoding:NSASCIIStringEncoding];
 					


### PR DESCRIPTION
The cause of the truncation was C-strings being turned into NSStrings with NSData, which copies the nulls into the NSStrings. These nulls cause truncation.
