### PR TITLE
Add check for empty or nil rawData (one less error log)

### DIFF
--- a/Classes/Library/TLOFileLogger.m
+++ b/Classes/Library/TLOFileLogger.m
@@ -209,7 +209,9 @@
 {
 	if (self.writePlainText == NO) {
 		NSData *rawData = [_NSFileManager() contentsAtPath:self.filename];
-
+		if (PointerIsEmpty(rawData) || rawData.length == 0)
+			return [NSDictionary dictionary];
+		
 		NSString *readError;
 
 		NSDictionary *plist = [NSPropertyListSerialization propertyListFromData:rawData


### PR DESCRIPTION
I get spammed in Console:
2012-08-10 23:00:09.615 Textual[12210:303] -[TLOFileLogger propertyList] [Line 221]: Error Reading Property List: Cannot parse a NULL or zero-length data

This fixes that.
