### PR TITLE
Fix sysinfo truncation, hopefully for good

### DIFF
--- a/Resources/Plugins/System Profiler/TPI_SP_SysInfo.m
+++ b/Resources/Plugins/System Profiler/TPI_SP_SysInfo.m
@@ -512,6 +512,7 @@
 					NSString *s = [NSString stringWithBytes:[(__bridge NSData *)model bytes]
 													 length:CFDataGetLength(model)
                                                    encoding:NSASCIIStringEncoding];
+                    s = [s stringByReplacingOccurrencesOfString:@"\0" withString:NSStringEmptyPlaceholder];
 					
                     [gpuList addObject:s];
                 }


### PR DESCRIPTION
Using [NSString stringWithChar:'\0'] didn't work...
