### PR TITLE
Add IRCNode to the network list.

### DIFF
--- a/Resources/Miscellaneous/IRCNetworks.plist
+++ b/Resources/Miscellaneous/IRCNetworks.plist
@@ -18,6 +18,8 @@
 	<string>irc.irchighway.net</string>
 	<key>IRCNet</key>
 	<string>ircnet.choopa.net</string>
+	<key>IRCNode</key>
+	<string>irc.ircnode.org</string>
 	<key>Mibbit</key>
 	<string>irc.mibbit.com</string>
 	<key>Mozilla</key>


### PR DESCRIPTION
Add IRCNode to the network list, a user peak of 80. IRCNode is a network that drives technology, gaming and development.

Thanks.
