### PR TITLE
Update message counter even if growl/MLNC notifications are disabled

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -2988,7 +2988,7 @@
 				}
 
 				/* Mark channel as unread. */
-				if (postevent && (highlight || c.config.pushNotifications)) {
+				if (postevent) {
 					[self setUnreadState:c];
 				}
 			}];


### PR DESCRIPTION
Disabling channel notifications or system notifications disables the unread count and the last seen bar. This is undesirable.
