### PR TITLE
This prevents WHO commands on inactive channels.

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -6140,7 +6140,7 @@
 
     if ([TPCPreferences processChannelModes] && self.CAPawayNotify == NO) {
         for (IRCChannel *channel in self.channels) {
-            if (channel.isChannel && channel.memberList.count <= [TPCPreferences trackUserAwayStatusMaximumChannelSize]) {
+            if (channel.isChannel && channel.isActive && channel.memberList.count <= [TPCPreferences trackUserAwayStatusMaximumChannelSize]) {
                 [self send:IRCPrivateCommandIndex("who"), channel.name, nil];
             }
         }


### PR DESCRIPTION
If a channel is in the list but not actually joined, we shouldn't send WHO commands when the ISON timer fires, because it produces a lot of additional traffic and isn't useful in this manner.
