### PR TITLE
Display outgoing notices in the selected channel

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -1409,9 +1409,11 @@
 					IRCChannel *channel = [self findChannel:channelName];
 
 					if (PointerIsEmpty(channel) && secretMsg == NO) {
-						if ([channelName isChannelName:self] == NO) {
-							channel = [self.worldController createPrivateMessage:channelName client:self];
-						}
+						if ([channelName isChannelName:self] == NO && type == TVCLogLineNoticeType) {
+							channel = [self.worldController selectedChannel];
+						} else if ([channelName isChannelName:self]) {
+                            channel = [self.worldController createPrivateMessage:channelName client:self];
+                        }
 					}
 
 					if (channel) {


### PR DESCRIPTION
Outgoing notices should be displayed in the selected channel instead of treated like a private message.
