### PR TITLE
Fix: insert action on double click not working as expected

### DIFF
--- a/Classes/Controllers/TXMenuController.m
+++ b/Classes/Controllers/TXMenuController.m
@@ -1411,12 +1411,9 @@
     NSInteger n = [view rowAtPoint:pt];
     
     if (n >= 0) {
-        if (NSObjectIsNotEmpty(view.selectedRowIndexes)) {
-            [view selectItemAtIndex:n];
-        }
-
+        
 		TXUserDoubleClickAction action = [TPCPreferences userDoubleClickOption];
-
+        
 		if (action == TXUserDoubleClickWhoisAction) {
 			[self whoisSelectedMembers:nil deselect:NO];
 		} else if (action == TXUserDoubleClickPrivateMessageAction) {
@@ -1431,31 +1428,31 @@
 {
 	IRCClient *u = [self.worldController selectedClient];
 	IRCChannel *c = [self.worldController selectedChannel];
-
+    
 	if (_noClient || _isClient) {
 		return;
 	}
-
+    
 	/* Get list of users. */
 	NSMutableArray *users = [NSMutableArray array];
-
+    
 	for (IRCUser *m in [self selectedMembers:sender]) {
 		[users safeAddObject:m.nickname];
 	}
-
+    
 	/* The text field. */
 	TVCInputTextField *textField = self.masterController.inputTextField;
-
+    
 	NSRange selectedRange = textField.selectedRange;
-
+    
 	NSInteger insertLocation = selectedRange.location;
-
+    
 	/* Build insert string. */
 	NSString *insertString;
-
+    
 	if (insertLocation > 0) {
 		UniChar prev = [textField.stringValue characterAtIndex:(insertLocation - 1)];
-
+        
 		if (prev == ' ') {
 			insertString = NSStringEmptyPlaceholder;
 		} else {
@@ -1464,17 +1461,25 @@
 	} else {
 		insertString = NSStringEmptyPlaceholder;
 	}
-
+    
 	insertString = [insertString stringByAppendingString:[users componentsJoinedByString:@", "]];
-	insertString = [insertString stringByAppendingString:[TPCPreferences tabCompletionSuffix]];
-
+    
+    if([TPCPreferences tabCompletionSuffix]) {
+        insertString = [insertString stringByAppendingString:[TPCPreferences tabCompletionSuffix]];
+    }
+    
 	/* Insert names. */
 	NSAttributedString *stringInsert = [NSAttributedString emptyStringWithBase:insertString];
-
+    
 	NSData *stringData = [stringInsert RTFFromRange:NSMakeRange(0, [stringInsert length]) documentAttributes:nil];
-
+    
     [textField replaceCharactersInRange:selectedRange withRTF:stringData];
-
+    
+    if([TPCPreferences invertInputTextFieldColors] == YES){
+        [self.masterController.inputTextField updateTextColor];
+        [self.masterController.inputTextField setNeedsDisplay:YES];
+    }
+    
 	/* Close users. */
 	[self deselectMembers:sender];
 }


### PR DESCRIPTION
I changed 3 things to make this feature working as expected:
1. if no autocomplete suffix is set in the prefs, it results in a nil argument error. 
   This has been fixed.
2. If the experimental setting "darken input textfield colors" is set, the inserted text is in black colour instead of white as expected.
   Now the inserted nicknames are in white colour like the rest of the text.
3. Selecting multiple nicknames from the member list wasn't possible due to some unnecessary code.
