### PR TITLE
Set focus to the input textfield after insert action.

### DIFF
--- a/Classes/Controllers/TXMenuController.m
+++ b/Classes/Controllers/TXMenuController.m
@@ -1482,6 +1482,9 @@
 
 	/* Close users. */
 	[self deselectMembers:sender];
+    
+    /* Set focus to the input textfield. */
+    [[textField window] makeFirstResponder:textField];
 }
 
 - (void)memberSendWhois:(id)sender

--- a/Resources/Plugins/ZNC Additions/TPI_ZNCAdditions.m
+++ b/Resources/Plugins/ZNC Additions/TPI_ZNCAdditions.m
@@ -70,8 +70,8 @@
 {
 	for (IRCChannel *c in client.channels) {
 		NSAssertReturnLoopContinue(c.isActive);
-
-		[c deactivate];
+        NSAssertReturnLoopContinue(![c.name hasPrefix:@"~"]);
+        [c deactivate];
 	}
 
 	[self.worldController reloadTreeGroup:client];


### PR DESCRIPTION
Set the focus back to the input textfield after insert action so the user can continue with typing seamlessly.
