### PR TITLE
fix to intermittent crashes on server disconnects when the server is configured to use a proxy

### DIFF
--- a/Classes/IRC/IRCConnectionSocket.m
+++ b/Classes/IRC/IRCConnectionSocket.m
@@ -246,7 +246,9 @@
 - (void)onSocket:(id)sender willDisconnectWithError:(NSError *)error
 {
 	if (PointerIsEmpty(error) || [error code] == errSSLClosedGraceful) {
-		[self onSocketDidDisconnect:sender];
+		if ([self useNewSocketEngine]) {
+			[self onSocketDidDisconnect:sender];
+		}
 	} else {
 		NSString *errorMessage = nil;
 


### PR DESCRIPTION
connection when proxies are used.

Proxies use AsyncSocket's closeWithError: message to perform a socket close.
There are scenarios where the NSError parameter is nil and is passed to the 
delegate's willDisconnectWithError: message. IRCConnectionSocket will then
cleanup the socket by destroying its memory and the delegate's and setting
both references to nil, which isn't correct since AsyncSocket's closeWithError:
message calls close on the socket after the willDisconnectWithError: message.
