### PR TITLE
Enhancing the drawing of highlighted messages

### DIFF
--- a/Classes/Headers/TVCServerList.h
+++ b/Classes/Headers/TVCServerList.h
@@ -99,6 +99,7 @@
 - (NSColor *)messageCountBadgeAquaBackgroundColor;
 - (NSColor *)messageCountBadgeGraphtieBackgroundColor;
 - (NSColor *)messageCountBadgeHighlightBackgroundColor;
+- (NSColor *)privateMessageCountBadgeHighlightBackgroundColor;
 - (NSColor *)messageCountBadgeNormalTextColor;
 - (NSColor *)messageCountBadgeSelectedBackgroundColor;
 - (NSColor *)messageCountBadgeSelectedTextColor;

--- a/Classes/Views/Server List/TVCServerList.m
+++ b/Classes/Views/Server List/TVCServerList.m
@@ -347,8 +347,14 @@
 
 - (NSColor *)messageCountBadgeHighlightBackgroundColor
 {
-	return [NSColor defineUserInterfaceItem:[NSColor internalCalibratedRed:210 green:15 blue:15 alpha:1.0]
-							   invertedItem:[NSColor internalCalibratedRed:141.0 green:0.0 blue:0.0  alpha:1.0]];
+	return [NSColor defineUserInterfaceItem:[NSColor internalCalibratedRed:122 green:178 blue:72 alpha:1.0]
+           						   invertedItem:[NSColor internalCalibratedRed:0.0 green:100.0 blue:0.0  alpha:1.0]];
+}
+
+- (NSColor *)privateMessageCountBadgeHighlightBackgroundColor
+{
+	return [NSColor defineUserInterfaceItem:[NSColor internalCalibratedRed:213 green:112 blue:110 alpha:1.0]
+                              invertedItem:[NSColor internalCalibratedRed:141.0 green:0.0 blue:0.0  alpha:1.0]];
 }
 
 - (NSColor *)messageCountBadgeAquaBackgroundColor


### PR DESCRIPTION
Implementation of the following feature request:
https://groups.google.com/forum/?fromgroups=#!category-topic/textual-support-group/feature-requests/U0j8pTu0OiA

Highlighted number of messages will be drawn in the channel/query badge
right before the total number of available messages The highlighted number
of messages will be painted with a green color as part of an overall oval
shaped badge.
