### PR TITLE
Fix troubling System SOCKS "Invalid Argument" error

### DIFF
--- a/Classes/Library/External Libraries/Sockets/GCDAsyncSocketExtensions.m
+++ b/Classes/Library/External Libraries/Sockets/GCDAsyncSocketExtensions.m
@@ -173,7 +173,7 @@
 	CFDictionaryRef settings = SCDynamicStoreCopyProxies(NULL);
 
     // Check to see if there _is_ a system SOCKS proxy set.
-    if (CFDictionaryGetValueIfPresent(settings,CFItemRefToID(kCFStreamPropertySOCKSProxyHost), NULL)) {
+    if (CFDictionaryGetValueIfPresent(settings, CFItemRefToID(kCFStreamPropertySOCKSProxyHost), NULL)) {
         CFReadStreamSetProperty(theReadStream, kCFStreamPropertySOCKSProxy, settings);
         CFWriteStreamSetProperty(theWriteStream, kCFStreamPropertySOCKSProxy, settings);
     }


### PR DESCRIPTION
A strange issue comes up when I utilize Textual with my wifi turned off and my thunderbolt ethernet plugged in. I use the System SOCKS Proxy preference in all my IRC connections, so it's important that when I switch to network location "Automatic", the location without any proxies, that Textual will always switch to this location successfully.

What happens instead is the client attempts to connect and gets an "Invalid Argument" error. I know not that much about Obj-C & CFNetwork stuff and would really just like to see this issue fixed, so here is a pull request to what I think resolves the core issue, but please take a deeper look.

TL;DR I believe we need to check for a set system socks proxy before trying to force the CFSocket pair to connect over SOCKS. I am uncertain as to why Textual works just fine with my main interface (enumerated at en0) but not my ethernet interface (enumerated as en2).
