### PR TITLE
Re-introduce missing Limechat copyright notice

### DIFF
--- a/README
+++ b/README
@@ -21,6 +21,8 @@ approve apps in the Mac App Store. If you wish to build Textual for
 yourself, proceed at your own risk.
 
 #### License ####
+Copyright (c) 2008-2010  Satoshi Nakagawa  <psychs AT limechat DOT net>
+All rights reserved.
 
 Copyright (c) 2010 — 2013 Codeux Software & respective contributors.
        Please see Contributors.pdf and Acknowledgements.pdf


### PR DESCRIPTION
The license under which Limechat's source code appears\* to have been forked to form the basis of Textual stated: "[r]edistributions of source code must retain the above copyright notice". This makes your license compliant with that.
- https://github.com/psychs/limechat/commit/b23f9bb406071b3972461bbf1063906f179c367c
