### PR TITLE
Fix server-time support

### DIFF
--- a/Classes/IRC/IRCMessage.m
+++ b/Classes/IRC/IRCMessage.m
@@ -102,10 +102,10 @@
 
 				NSAssertReturnLoopBreak(hasTimeExt);
 
-				NSDate *date = [NSDate dateWithTimeIntervalSince1970:[extVal doubleValue]];
-
+				NSDate *date = [self.worldController.isoStandardDateFormatter dateFromString:extVal];
+				
 				if (PointerIsEmpty(date)) {
-					date = [self.worldController.isoStandardDateFormatter dateFromString:extVal];
+					date = [NSDate dateWithTimeIntervalSince1970:[extVal doubleValue]];
 				}
 
 				if (date) {


### PR DESCRIPTION
Actually interpreting an iso date string as double value doesn't result in an empty pointer.
So this is my fix, tested with both implementations.
