### PR TITLE
Fix: Show quit messages in buffer playback

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -4007,7 +4007,7 @@
 	}
 
 	for (IRCChannel *c in self.channels) {
-		if ([c findMember:sendern]) {
+		if ([c findMember:sendern] || [[m.params objectAtIndex:0] isEqualToString:c.name]) {
 			/* We send quit messages to private messages regardless of user preference. */
 			if (([TPCPreferences showJoinLeave] && [ignoreChecks ignoreJPQE] == NO && c.config.ignoreJPQActivity == NO) || myself || c.isPrivateMessage) {
 				if (c.isPrivateMessage) {

--- a/Resources/Plugins/ZNC Additions/TPI_ZNCAdditions.m
+++ b/Resources/Plugins/ZNC Additions/TPI_ZNCAdditions.m
@@ -183,7 +183,7 @@
 
 		input.command = IRCPrivateCommandIndex("quit");
 
-		[input.params removeAllObjects];
+		[input.params removeObjectAtIndex:1];
 
 		[input.params safeAddObject:s];
 		/* End quit message. */


### PR DESCRIPTION
This is my workaround for displaying quit messages in the ZNC playback buffer.
I know it isn't the cleanest solution but it works.
