### PR TITLE
attempt to ignore non-alphas during autocomplete

### DIFF
--- a/Classes/Library/TLONickCompletionStatus.m
+++ b/Classes/Library/TLONickCompletionStatus.m
@@ -372,11 +372,25 @@
 		[upperChoices safeAddObject:client.isupport.networkNameActual];
 	}
 
-	lowerChoices = [upperChoices mutableCopy];
+/*  lowerChoices = [upperChoices mutableCopy];
 
-	/* Quick method for replacing the value of each array
-	 object based on a provided selector. */
-	[lowerChoices performSelectorOnObjectValueAndReplace:@selector(lowercaseString)];
+  /* Quick method for replacing the value of each array
+   object based on a provided selector. */
+  [lowerChoices performSelectorOnObjectValueAndReplace:@selector(lowercaseString)];
+*/
+
+  NSArray *tempChoices = [upperChoices copy];
+  NSCharacterSet *nonAlpha = [NSCharacterSet characterSetWithCharactersInString:@"^[]-_`{}"]
+  [upperChoices removeAllObjects];
+  for (NSString *s in tempChoices) {
+    [lowerChoices safeAddObject:s];
+    [upperChoices safeAddObject:s];
+    NSString *stripped = [s stringByTrimmingCharactersInSet:nonAlpha];
+    if (stripped != s ) {
+      [lowerChoices safeAddObject:stripped];
+      [upperChoices safeAddObject:s];
+    }
+  }
 
 	/* We will now get a list of matches to our backward cut. */
 	NSMutableArray *currentUpperChoices = [NSMutableArray array];


### PR DESCRIPTION
I'm not setup to build and compiled Textual right now so I was hoping someone would want to help me with this... I think this is the gist of what needs to be done... the idea is that you can autocomplete weird nicks without having to type the weird characters.  irssi has done this for decades.

```
bob[tab] => `bob
suzy[tab] => [suzy]
```

You get the idea.  This attempts to do this by simply adding stripped matches to the lowercase array and then having their matches duplicated in the uppercase array.  This should allow either the exact string, or alpha-only to match.  So now the arrays your searching thru look like:

```
lower: [..., "bob", "`bob", ...]
upper: [..., "`bob", "`bob", ...] 

lower: [..., "suzy", "[suzy]", ...]
lower: [..., "[suzy]", "[suzy]", ...]
```

Feedback or suggestions welcome.  Again I can't test and compile this right now but was hoping someone else who's run into this same issue would be willing to assist.
