### PR TITLE
Linkify message: links in the log renderer.

### DIFF
--- a/Classes/Helpers/Cocoa (Objective-C)/NSStringHelper.m
+++ b/Classes/Helpers/Cocoa (Objective-C)/NSStringHelper.m
@@ -425,6 +425,10 @@
 		return [@"http://www.reddit.com" stringByAppendingString:self];
 	}
 
+    /* Short-circuit for message:(\/\/)? links. */
+    if ([self hasPrefix:@"message:"])
+        return self;
+
 	/* Normal links. */
 	if ([self contains:@"://"] == NO) {
 		return [NSString stringWithFormat:@"http://%@", self];

--- a/Frameworks/Auto Hyperlinks/Source/Source/AHLinkLexer.l
+++ b/Frameworks/Auto Hyperlinks/Source/Source/AHLinkLexer.l
@@ -69,6 +69,7 @@ msnSpec         msnim:(chat|add|voice|video)\?contact={mailSpec}
 dictSpec		dict:{urlPath}
 magnetSpec		magnet:\?xt\=urn:btih:([A-Fa-f0-9]{40})[^[:space:]]*
 redditSpec		\/r\/[A-Za-z0-9][A-Za-z0-9_]{2,20}
+messageSpec		message:(\/\/)?(%3[Cc]).+(%3[Ee])
 
 ignoreable      (b\.sc|m\.in)
 
@@ -124,6 +125,7 @@ x-man-page:\/\/         {yyextra = yyleng; BEGIN CANONICAL;}
 {dictSpec}				|
 {magnetSpec}			|
 {redditSpec}			|
+{messageSpec}			|
 {spotifySpec}           {return AHValidURL;}
 
 .                       {return AHInvalidURL;}


### PR DESCRIPTION
Mail.app supports using message: links to open a Mail message from outside of the app. See here for details: http://daringfireball.net/2007/12/message_urls_leopard_mail

This patch adds support for linkifying message: links automatically.
