### PR TITLE
add a 'Move Backward' menu option; rename selectNextSelection to selectN...

### DIFF
--- a/Classes/Controllers/TXMasterController.m
+++ b/Classes/Controllers/TXMasterController.m
@@ -1055,7 +1055,7 @@ typedef enum TXMoveKind : NSInteger {
 	[self.worldController selectPreviousItem];
 }
 
-- (void)selectNextSelection:(NSEvent *)e
+- (void)selectNextWindow:(NSEvent *)e
 {
 	[self move:TXMoveAllKind target:TXMoveDownKind];
 }

--- a/Classes/Controllers/TXMenuController.m
+++ b/Classes/Controllers/TXMenuController.m
@@ -134,6 +134,7 @@
 		case 50010: // "Previous Unread Channel"
 		case 50011: // "Previous Selection"
 		case 50012: // "Move Forward"
+		case 50013: // "Move Backward"
 		case 521: // "Add Server…"
 		case 542: // "Logs"
 		case 5675: // "Connect to Help Channel"
@@ -2073,7 +2074,8 @@
 		case 50009: { [self.masterController selectNextUnreadChannel:nil]; break;			}
 		case 50010: { [self.masterController selectPreviousUnreadChannel:nil]; break;		}
 		case 50011: { [self.masterController selectPreviousSelection:nil]; break;			}
-		case 50012: { [self.masterController selectNextSelection:nil]; break;				}
+		case 50012: { [self.masterController selectNextWindow:nil]; break;				}
+		case 50013: { [self.masterController selectPreviousWindow:nil]; break;				}
 	}
 }
 

--- a/Classes/Headers/TXMasterController.h
+++ b/Classes/Headers/TXMasterController.h
@@ -97,9 +97,10 @@
 
 - (void)selectNextServer:(NSEvent *)e;
 - (void)selectNextChannel:(NSEvent *)e;
-- (void)selectNextSelection:(NSEvent *)e;
+- (void)selectNextWindow:(NSEvent *)e;
 - (void)selectPreviousServer:(NSEvent *)e;
 - (void)selectPreviousChannel:(NSEvent *)e;
+- (void)selectPreviousWindow:(NSEvent *)e;
 - (void)selectNextActiveServer:(NSEvent *)e;
 - (void)selectNextUnreadChannel:(NSEvent *)e;
 - (void)selectNextActiveChannel:(NSEvent *)e;
@@ -107,7 +108,6 @@
 - (void)selectPreviousActiveServer:(NSEvent *)e;
 - (void)selectPreviousUnreadChannel:(NSEvent *)e;
 - (void)selectPreviousActiveChannel:(NSEvent *)e;
-- (void)selectPreviousWindow:(NSEvent *)e;
 @end
 
 @interface NSObject (TXMasterControllerObjectExtension)

--- a/Classes/Headers/TXMenuController.h
+++ b/Classes/Headers/TXMenuController.h
@@ -76,6 +76,7 @@
 	50010: "Previous Unread Channel"
 	50011: "Previous Selection"
 	50012: "Move Forward"
+	50013: "Move Backward"
 	501: "Connect"
 	502: "Disconnect"
 	503: "Cancel Reconnect"

--- a/Classes/Views/TVCMainWindow.m
+++ b/Classes/Views/TVCMainWindow.m
@@ -88,7 +88,7 @@ static NSValue *touchesToPoint(NSTouch *fingerA, NSTouch *fingerB) {
     CGFloat x = [event deltaX];
 	
     if (x > 0) {
-        [self.masterController selectNextSelection:nil];
+        [self.masterController selectNextWindow:nil];
     } else if (x < 0) {
         [self.masterController selectPreviousWindow:nil];
     }
@@ -139,7 +139,7 @@ static NSValue *touchesToPoint(NSTouch *fingerA, NSTouch *fingerB) {
 	if (delta.x > 0) {
 		[self.masterController selectPreviousWindow:nil];
 	} else {
-		[self.masterController selectNextSelection:nil];
+		[self.masterController selectNextWindow:nil];
 	}
 }
 


### PR DESCRIPTION
...extWindow for consistency

Having a Move Forward but no Move Backward (only a Previous Selection toggle) is frustrating.  Functionality for Move Backward already exists, this patch just exposes it in the UI so I can add a keybinding.  Also, renamed a method for consistency.

I gave up fighting xcode to get this to build, so patch is untested; sorry about that. :(
