### PR TITLE
Add support for width formatting in nick

### DIFF
--- a/Resources/Styles/Styles/Astria/design.css
+++ b/Resources/Styles/Styles/Astria/design.css
@@ -215,6 +215,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Lucidity/design.css
+++ b/Resources/Styles/Styles/Lucidity/design.css
@@ -200,6 +200,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Matrix by bogo_lode/design.css
+++ b/Resources/Styles/Styles/Matrix by bogo_lode/design.css
@@ -217,6 +217,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: normal;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Sapientia/design.css
+++ b/Resources/Styles/Styles/Sapientia/design.css
@@ -214,6 +214,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Simplified Dark/design.css
+++ b/Resources/Styles/Styles/Simplified Dark/design.css
@@ -212,6 +212,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Simplified Light Blue/design.css
+++ b/Resources/Styles/Styles/Simplified Light Blue/design.css
@@ -214,6 +214,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Simplified Light/design.css
+++ b/Resources/Styles/Styles/Simplified Light/design.css
@@ -211,6 +211,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */


### PR DESCRIPTION
Adds support for specifying a minimum width for nick display. For example with
a nick format of `<%-9n>` the nick `bd808` will be rendered as `<    bd808>`.

Code taken from
https://github.com/psychs/limechat/blob/master/Classes/IRC/IRCClient.m at hash
4a1e187dc81cabd5bba35a0a26ea7ab3c963326e
