### PR TITLE
Add support for minimum width formatting in nick

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -2651,29 +2651,59 @@
 		nmformat = forcedFormat;
 	}
 
-	if ([nmformat contains:@"%n"]) {
-		nmformat = [nmformat stringByReplacingOccurrencesOfString:@"%n" withString:nick];
-	}
-
-	if ([nmformat contains:@"%@"]) {
-		if (channel && channel.isChannel) {
-			IRCUser *m = [channel findMember:nick];
-
-			if (m) {
-				if (NSObjectIsEmpty(m.mark)) {
-					nmformat = [nmformat stringByReplacingOccurrencesOfString:@"%@" withString:NSStringEmptyPlaceholder];
-				} else {
-					nmformat = [nmformat stringByReplacingOccurrencesOfString:@"%@" withString:m.mark];
-				}
-			} else {
-				nmformat = [nmformat stringByReplacingOccurrencesOfString:@"%@" withString:NSStringEmptyPlaceholder];
-			}
-		} else {
-			nmformat = [nmformat stringByReplacingOccurrencesOfString:@"%@" withString:NSStringEmptyPlaceholder];
+  NSString *mark = NSStringEmptyPlaceholder;
+  if (channel && channel.isChannel) {
+    IRCUser *m = [channel findMember:nick];
+    if (m && NSObjectIsNotEmpty(m.mark)) {
+      mark = m.mark;
 		}
-	}
+  }
 
-	return nmformat;
+  NSString *formatMarker = @"%";
+  NSScanner *scanner = [NSScanner scannerWithString:nmformat];
+  [scanner setCharactersToBeSkipped:nil];
+  NSMutableString *buffer = [NSMutableString new];
+  NSString *chunk = nil;
+
+  while ([scanner isAtEnd] == NO) {
+    // read any static characters into buffer
+    if ([scanner scanUpToString:formatMarker intoString:&chunk] == YES) {
+      [buffer appendString:chunk];
+    }
+
+    // eat the format marker
+    if ([scanner scanString:formatMarker intoString:nil] == NO) {
+      break;
+    }
+
+    // read width specifier (may be empty)
+    NSInteger width = 0;
+    [scanner scanInteger:&width];
+
+    // read the output type marker
+    NSString *oValue = nil;
+    if ([scanner scanString:@"@" intoString:nil] == YES) {
+      oValue = mark;
+
+    } else if ([scanner scanString:@"n" intoString:nil] == YES) {
+      oValue = nick;
+
+    } else if ([scanner scanString:formatMarker intoString:nil] == YES) {
+      oValue = formatMarker;
+    }
+
+    if (oValue != nil) {
+      if (width < 0 && ABS(width) > [oValue length]) {
+        [buffer appendString:[@"" stringByPaddingToLength:ABS(width)-[oValue length] withString:@" " startingAtIndex:0]];
+      }
+      [buffer appendString:oValue];
+      if (width > 0 && width > [oValue length]) {
+        [buffer appendString:[@"" stringByPaddingToLength:width-[oValue length] withString:@" " startingAtIndex:0]];
+      }
+    }
+  }
+
+	return [NSString stringWithString:buffer];
 }
 
 - (void)printAndLog:(TVCLogLine *)line completionBlock:(void(^)(BOOL highlighted))completionBlock

--- a/Resources/Styles/Styles/Astria/design.css
+++ b/Resources/Styles/Styles/Astria/design.css
@@ -215,6 +215,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Lucidity/design.css
+++ b/Resources/Styles/Styles/Lucidity/design.css
@@ -200,6 +200,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Matrix by bogo_lode/design.css
+++ b/Resources/Styles/Styles/Matrix by bogo_lode/design.css
@@ -217,6 +217,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: normal;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Sapientia/design.css
+++ b/Resources/Styles/Styles/Sapientia/design.css
@@ -214,6 +214,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Simplified Dark/design.css
+++ b/Resources/Styles/Styles/Simplified Dark/design.css
@@ -212,6 +212,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Simplified Light Blue/design.css
+++ b/Resources/Styles/Styles/Simplified Light Blue/design.css
@@ -214,6 +214,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */

--- a/Resources/Styles/Styles/Simplified Light/design.css
+++ b/Resources/Styles/Styles/Simplified Light/design.css
@@ -211,6 +211,7 @@ body div[type*=privmsg] p[type*=myself] .message {
 
 body div[type*=privmsg] .sender {
 	font-weight: 700;
+	white-space: pre-wrap;
 }
 
 /* ACTION */


### PR DESCRIPTION
Adds support for specifying a minimum width for nick display. Both the nick
(`%n`) and mark (`%@`) attributes can have specify a minimum width by adding
an integer describing the width following the percent character (`%`). If
a literal percent is desired in the formatted nick it must be escaped in the
format string by doubling (eg. `%%).

Example:
- format: `<%-9n>`
- nick: `bd808`
- result: `<    bd808>`.
