### PR TITLE
Fix channel list not appearing twice for the same network.

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -7231,7 +7231,7 @@
 
 - (void)listDialogWillClose:(TDCListDialog *)sender
 {
-    [self.masterController.menuController removeWindowFromWindowList:@"TDCListDialog"];
+    [self.masterController.menuController removeWindowFromWindowList:self.listDialogWindowKey];
 }
 
 #pragma mark -


### PR DESCRIPTION
Steps to reproduce: 
1. Connect to a network.
2. Enter "/list".
3. Close the channel list.
4. Enter "/list" again.

The channel list won't appear again.
