### PR TITLE
Fix UI glitch in adress book / ignore list.

### DIFF
--- a/Classes/Dialogs/TDCServerSheet.m
+++ b/Classes/Dialogs/TDCServerSheet.m
@@ -886,10 +886,6 @@
 
 - (void)showAddIgnoreMenu:(id)sender
 {
-	NSRect tableRect = self.ignoreTable.frame;
-	
-	tableRect.origin.y += (tableRect.size.height);
-	tableRect.origin.y += 34;
 
 	NSMenu *addIgnoreMenu = [NSMenu new];
 
@@ -907,7 +903,7 @@
 	[addIgnoreMenu addItem:item1];
 	[addIgnoreMenu addItem:item2];
     
-	[addIgnoreMenu popUpMenuPositioningItem:nil atLocation:tableRect.origin inView:self.ignoreTable];
+	[addIgnoreMenu popUpMenuPositioningItem:nil atLocation:NSMakePoint(156, 265) inView:self.tabView];
 }
 
 - (void)addIgnore:(id)sender


### PR DESCRIPTION
Steps to reproduce:
1. Click Window->Ignore List or Window->Adress Book.
2. Add more than 9 items to the list.
3. Make sure the list is scrolled to the top.
4. Click the + sign again.

The context menu appears at a wrong position.
