### PR TITLE
Don't activate app if reply sent via notification bubble (mavericks).

### DIFF
--- a/Classes/Library/TLOGrowlController.m
+++ b/Classes/Library/TLOGrowlController.m
@@ -254,9 +254,10 @@
 	self.lastClickedTime = now;
 	self.lastClickedContext = context;
 
-	[self.masterController.mainWindow makeKeyAndOrderFront:nil];
-
-	[NSApp activateIgnoringOtherApps:YES];
+	if (changeFocus) {
+		[self.masterController.mainWindow makeKeyAndOrderFront:nil];
+		[NSApp activateIgnoringOtherApps:YES];
+	}
 
 	if ([context isKindOfClass:[NSDictionary class]]) {
 		NSString *uid = [context objectForKey:@"client"];


### PR DESCRIPTION
Since the most useful situation for this feature is when Textual is not the front most application, it makes more sense to me if it doesn't become the front most application after the user entered the answer in the notification bubble.
So the user can seamlessly continue with doing the previously things.
