### PR TITLE
Fix error in /amsg and /ame if applies to all active connections.

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -2053,10 +2053,14 @@
 
 			if ([TPCPreferences amsgAllConnections]) {
 				for (IRCClient *client in self.worldController.clients) {
-					for (IRCChannel *channel in u.channels) {
-						[client setUnreadState:channel];
-						[client sendText:s command:IRCPrivateCommandIndex("privmsg") channel:channel];
-					}
+                    if(client.isConnected) {
+                        for (IRCChannel *channel in client.channels) {
+                            if(channel.isActive) {
+                                [client setUnreadState:channel];
+                                [client sendText:s command:IRCPrivateCommandIndex("privmsg") channel:channel];
+                            }
+                        }
+                    }
 				}
 			} else {
 				for (IRCChannel *channel in self.channels) {
@@ -2073,10 +2077,14 @@
 
 			if ([TPCPreferences amsgAllConnections]) {
 				for (IRCClient *client in self.worldController.clients) {
-					for (IRCChannel *channel in u.channels) {
-						[client setUnreadState:channel];
-						[client sendText:s command:IRCPrivateCommandIndex("action") channel:channel];
-					}
+                    if(client.isConnected) {
+                        for (IRCChannel *channel in client.channels) {
+                            if(channel.isActive) {
+                                [client setUnreadState:channel];
+                                [client sendText:s command:IRCPrivateCommandIndex("action") channel:channel];
+                            }
+                        }
+                    }
 				}
 			} else {
 				for (IRCChannel *channel in self.channels) {


### PR DESCRIPTION
Steps to reproduce:
1. Make sure there are some other inactive (not connected) connections besides the selected one.
2. Activate "/amsg and /me applies to all active connections" in Preferences->Advanced->Command Scope
3. Enter /amsg sample text or /ame sample text

The selected channel will be spammed by lots of messages, one for each channel in each inactive connection.
