### PR TITLE
Check clearance but still highlight line

### DIFF
--- a/Classes/Views/Channel View/TVCLogRenderer.m
+++ b/Classes/Views/Channel View/TVCLogRenderer.m
@@ -561,10 +561,10 @@ static NSInteger getNextAttributeRange(attr_t *attrBuf, NSInteger start, NSInteg
 
 						/* Found a match. */
 						if (enabled) {
+							foundKeyword = YES;
+							
 							if (isClear(attrBuf, _rendererURLAttribute, matchRange.location, matchRange.length)) {
 								setFlag(attrBuf, _rendererKeywordHighlightAttribute, matchRange.location, matchRange.length);
-								
-								foundKeyword = YES;
 								
 								break;
 							}


### PR DESCRIPTION
This still allows the line to show up as a highlight, but it doesn't break the creation of the anchor tag from the raw URL.
