### PR TITLE
Enable localStorage API in WebView

### DIFF
--- a/Classes/Views/Channel View/TVCLogController.m
+++ b/Classes/Views/Channel View/TVCLogController.m
@@ -40,6 +40,11 @@
 
 #define _internalPlaybackLineCountLimit			100
 
+@interface WebPreferences (WebPreferencesPrivate)
+- (void)_setLocalStorageDatabasePath:(NSString *)path;
+- (void) setLocalStorageEnabled: (BOOL) localStorageEnabled;
+@end
+
 @interface TVCLogController ()
 @property (nonatomic, readonly, uweak) TPCThemeSettings *themeSettings;
 @property (nonatomic, assign) BOOL historyLoaded;
@@ -116,8 +121,11 @@
 
 	self.view.shouldUpdateWhileOffscreen = NO;
 
+  [self.view.preferences setAutosaves:YES];
 	[self.view.preferences setCacheModel:WebCacheModelDocumentViewer];
 	[self.view.preferences setUsesPageCache:NO];
+  [self.view.preferences _setLocalStorageDatabasePath:@"~/Library/Textual/LocalStorage"];
+  [self.view.preferences setLocalStorageEnabled:YES];
 
 	[self loadAlternateHTML:[self initialDocument:nil]];
 


### PR DESCRIPTION
Use the undocumented private API of WebPreferences to enable persistent
localStorage support in the WebView instances used to display log lines. This
allows javascript extensions to store data that will persist across Textual
restarts.

According to self reported results posted on StackOverflow Apple has accepted
applications using these same API calls for publication via the AppStore, but
I can make no personal guarantees that this is correct. If Apple will not
allow it it would still be nice to include this small patch via a #define that
could be enabled when compiling locally. Having the ability to store data via
javascript will enable a large number of advanced scripting possibilities such
as complex highlighting and persistent nick colorization.
