### PR TITLE
Add Interlinked to IRC network list

### DIFF
--- a/Resources/Miscellaneous/IRCNetworks.plist
+++ b/Resources/Miscellaneous/IRCNetworks.plist
@@ -20,6 +20,8 @@
 	<string>irc.gamesurge.net</string>
 	<key>German Elite</key>
 	<string>irc.german-elite.net</string>
+	<key>Interlinked</key>
+	<string>irc.interlinked.me</string>
 	<key>IRCHighWay</key>
 	<string>irc.irchighway.net</string>
 	<key>IRCNet</key>


### PR DESCRIPTION
Interlinked is a bigger network than some of those already listed.

Thanks for the great client.
