### PR TITLE
Display peer certificate when connecting to untrusted server

### DIFF
--- a/Classes/Headers/IRCClient.h
+++ b/Classes/Headers/IRCClient.h
@@ -64,6 +64,7 @@ typedef enum IRCDisconnectMode : NSInteger {
 @property (nonatomic, strong) IRCISupportInfo *isupport;
 @property (nonatomic, assign) IRCConnectMode connectType;
 @property (nonatomic, assign) IRCDisconnectMode disconnectType;
+@property (nonatomic, strong) NSData *serverSSLCertificateDER;
 @property (nonatomic, assign) NSInteger connectDelay;
 @property (nonatomic, assign) BOOL inUserInvokedNamesRequest;
 @property (nonatomic, assign) BOOL inUserInvokedWhoRequest;

--- a/Classes/Headers/TextualApplication.h
+++ b/Classes/Headers/TextualApplication.h
@@ -249,6 +249,7 @@
 	#import "THOPluginManager.h"
 	#import "THOPluginProtocol.h"
 	#import "THOUnicodeHelper.h"
+    #import "THOX509Certificate.h"
 
 	/* Library. */
 

--- a/Classes/Helpers/THOX509Certificate.h
+++ b/Classes/Helpers/THOX509Certificate.h
@@ -1,0 +1,33 @@
+//
+//  THOX509Certificate.h
+//  Main Project (Textual)
+//
+//  Created by Denis Dzyubenko on 24/11/13.
+//  Copyright (c) 2013 Codeux Software. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface THOX509CertificateObject : NSObject
+
+@property (nonatomic, strong) NSString *commonName;             // CN
+@property (nonatomic, strong) NSString *organizationName;       //  O
+@property (nonatomic, strong) NSString *country;                //  C
+@property (nonatomic, strong) NSString *stateOrProvince;        // ST
+@property (nonatomic, strong) NSString *location;               //  L
+@property (nonatomic, strong) NSString *organizationalUnitName; // OU
+
+@end
+
+@interface THOX509Certificate : NSObject
+
+@property (nonatomic, strong) THOX509CertificateObject *issuer;
+@property (nonatomic, strong) THOX509CertificateObject *subject;
+@property (nonatomic, strong) NSData *serial;
+
+@property (nonatomic, strong) NSDate *notBefore;
+@property (nonatomic, strong) NSDate *notAfter;
+
+- (instancetype)initWithDER:(NSData *)data;
+
+@end

--- a/Classes/Helpers/THOX509Certificate.m
+++ b/Classes/Helpers/THOX509Certificate.m
@@ -1,0 +1,116 @@
+//
+//  THOX509Certificate.m
+//  Main Project (Textual)
+//
+//  Created by Denis Dzyubenko on 24/11/13.
+//  Copyright (c) 2013 Codeux Software. All rights reserved.
+//
+
+#import "THOX509Certificate.h"
+#import <openssl/x509.h>
+
+static NSString *field(X509_NAME *name, const char *txt)
+{
+    int nid = OBJ_txt2nid(txt);
+    int index = X509_NAME_get_index_by_NID(name, nid, -1);
+    X509_NAME_ENTRY *entry = X509_NAME_get_entry(name, index);
+    if (entry) {
+        ASN1_STRING *issuerNameASN1 = X509_NAME_ENTRY_get_data(entry);
+        if (issuerNameASN1) {
+            unsigned char *issuerName = ASN1_STRING_data(issuerNameASN1);
+            return [NSString stringWithUTF8String:(char *)issuerName];
+        }
+    }
+    return nil;
+}
+
+static NSDate *asn1time_to_nsdate(ASN1_TIME *asn1time)
+{
+    ASN1_GENERALIZEDTIME *asn1generalizedtime = ASN1_TIME_to_generalizedtime(asn1time, NULL);
+    if (asn1generalizedtime) {
+        unsigned char *certificateExpiryData = ASN1_STRING_data(asn1generalizedtime);
+
+        // ASN1 generalized times look like this: "20131114230046Z"
+        //                                format:  YYYYMMDDHHMMSS
+        //                               indices:  01234567890123
+        //                                                   1111
+        // There are other formats (e.g. specifying partial seconds or
+        // time zones) but this is good enough for our purposes since
+        // we only use the date and not the time.
+        //
+        // (Source: http://www.obj-sys.com/asn1tutorial/node14.html)
+
+        NSString *expiryTimeStr = [NSString stringWithUTF8String:(char *)certificateExpiryData];
+        NSDateComponents *expiryDateComponents = [[NSDateComponents alloc] init];
+
+        expiryDateComponents.year   = [[expiryTimeStr substringWithRange:NSMakeRange(0, 4)] intValue];
+        expiryDateComponents.month  = [[expiryTimeStr substringWithRange:NSMakeRange(4, 2)] intValue];
+        expiryDateComponents.day    = [[expiryTimeStr substringWithRange:NSMakeRange(6, 2)] intValue];
+        expiryDateComponents.hour   = [[expiryTimeStr substringWithRange:NSMakeRange(8, 2)] intValue];
+        expiryDateComponents.minute = [[expiryTimeStr substringWithRange:NSMakeRange(10, 2)] intValue];
+        expiryDateComponents.second = [[expiryTimeStr substringWithRange:NSMakeRange(12, 2)] intValue];
+
+        NSCalendar *calendar = [NSCalendar currentCalendar];
+        return [calendar dateFromComponents:expiryDateComponents];
+    }
+    return nil;
+}
+
+static NSDate *notBefore(X509 *certificateX509)
+{
+    ASN1_TIME *asn1time = X509_get_notBefore(certificateX509);
+    return asn1time_to_nsdate(asn1time);
+}
+
+static NSDate *notAfter(X509 *certificateX509)
+{
+    ASN1_TIME *asn1time = X509_get_notAfter(certificateX509);
+    return asn1time_to_nsdate(asn1time);
+}
+
+@implementation THOX509CertificateObject
+@end
+
+@implementation THOX509Certificate
+
+- (instancetype)initWithDER:(NSData *)data
+{
+    self = [super init];
+    if (self) {
+        const unsigned char *bytes = (const unsigned char *)data.bytes;
+        X509 *x509cert = d2i_X509(NULL, &bytes, data.length);
+
+        _issuer = [[THOX509CertificateObject alloc] init];
+        X509_NAME *issuerX509Name = X509_get_issuer_name(x509cert);
+        if (issuerX509Name) {
+            _issuer.commonName = field(issuerX509Name, "CN");
+            _issuer.country = field(issuerX509Name, "C");
+            _issuer.stateOrProvince = field(issuerX509Name, "ST");
+            _issuer.location = field(issuerX509Name, "L");
+            _issuer.organizationalUnitName = field(issuerX509Name, "OU");
+            _issuer.organizationName = field(issuerX509Name, "O");
+        }
+
+        _subject = [[THOX509CertificateObject alloc] init];
+        X509_NAME *subjectX509Name = X509_get_subject_name(x509cert);
+        if (subjectX509Name) {
+            _subject.commonName = field(subjectX509Name, "CN");
+            _subject.country = field(subjectX509Name, "C");
+            _subject.stateOrProvince = field(subjectX509Name, "ST");
+            _subject.location = field(subjectX509Name, "L");
+            _subject.organizationalUnitName = field(subjectX509Name, "OU");
+            _subject.organizationName = field(subjectX509Name, "O");
+        }
+
+        _notBefore = notBefore(x509cert);
+        _notAfter = notAfter(x509cert);
+
+        ASN1_INTEGER *serialNumberX509 = X509_get_serialNumber(x509cert);
+        unsigned char *serialNumberData = ASN1_STRING_data(serialNumberX509);
+        int serialNumberLength = ASN1_STRING_length(serialNumberX509);
+        _serial = [NSData dataWithBytes:serialNumberData length:serialNumberLength];
+    }
+    return self;
+}
+
+@end

--- a/Classes/IRC/IRCConnectionSocket.m
+++ b/Classes/IRC/IRCConnectionSocket.m
@@ -250,6 +250,7 @@
 
 		if ([GCDAsyncSocket badSSLCertificateErrorFound:error]) {
 			self.client.disconnectType = IRCDisconnectBadSSLCertificateMode;
+            self.client.serverSSLCertificateDER = error.userInfo[@"peerCertificateDER"];
 		} else {
 			if ([error.domain isEqualToString:NSPOSIXErrorDomain]) {
 				errorMessage = [GCDAsyncSocket posixErrorStringFromError:error.code];

--- a/Classes/Library/External Libraries/Sockets/GCDAsyncSocket.m
+++ b/Classes/Library/External Libraries/Sockets/GCDAsyncSocket.m
@@ -2959,6 +2959,15 @@ static NSThread *cfstreamThread;  // Used for CFStreams
 	return [NSError errorWithDomain:@"kCFStreamErrorDomainSSL" code:ssl_error userInfo:userInfo];
 }
 
+- (NSError *)sslError:(OSStatus)ssl_error peerCertificateDER:(NSData *)peerCertificateDER
+{
+    NSParameterAssert(peerCertificateDER != NULL);
+	NSString *msg = @"Error code definition can be found in Apple's SecureTransport.h";
+	NSDictionary *userInfo = @{NSLocalizedRecoverySuggestionErrorKey : msg,
+                               @"peerCertificateDER" : peerCertificateDER};
+	return [NSError errorWithDomain:@"kCFStreamErrorDomainSSL" code:ssl_error userInfo:userInfo];
+}
+
 - (NSError *)connectTimeoutError
 {
 	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketConnectTimeoutError",
@@ -6563,7 +6572,27 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	}
 	else
 	{
-		[self closeWithError:[self sslError:status]];
+        NSData *certData = nil;
+        SecTrustRef trust = NULL;
+        SSLCopyPeerTrust(sslContext, &trust);
+        if (trust) {
+            CFIndex count = SecTrustGetCertificateCount(trust);
+            if (count == 1) {
+                SecCertificateRef cert = SecTrustGetCertificateAtIndex(trust, 0);
+                CFDataRef certDataRef = SecCertificateCopyData(cert);
+                certData = CFBridgingRelease(certDataRef);
+            } else {
+                LogWarn(@"Got too many peer certificated (expected 1 got %d)", count);
+            }
+            CFRelease(trust);
+        }
+        NSError *error;
+        if (certData) {
+            error = [self sslError:status peerCertificateDER:certData];
+        } else {
+            error = [self sslError:status];
+        }
+        [self closeWithError:error];
 	}
 }
 

--- a/Main Project (Textual).xcodeproj/project.pbxproj
+++ b/Main Project (Textual).xcodeproj/project.pbxproj
@@ -818,6 +818,10 @@
 		5D4846C4171F0AC00015F2B0 /* OELReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D4846C2171F0AC00015F2B0 /* OELReachability.m */; };
 		5D4846CA171F0ACD0015F2B0 /* OELReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4846C9171F0ACD0015F2B0 /* OELReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D4846CB171F0ACD0015F2B0 /* OELReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4846C9171F0ACD0015F2B0 /* OELReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		927F2E4C18428A6E0068890D /* THOX509Certificate.h in Headers */ = {isa = PBXBuildFile; fileRef = 927F2E4A18428A6E0068890D /* THOX509Certificate.h */; };
+		927F2E4D18428A6E0068890D /* THOX509Certificate.h in Headers */ = {isa = PBXBuildFile; fileRef = 927F2E4A18428A6E0068890D /* THOX509Certificate.h */; };
+		927F2E4E18428A6E0068890D /* THOX509Certificate.m in Sources */ = {isa = PBXBuildFile; fileRef = 927F2E4B18428A6E0068890D /* THOX509Certificate.m */; };
+		927F2E4F18428A6E0068890D /* THOX509Certificate.m in Sources */ = {isa = PBXBuildFile; fileRef = 927F2E4B18428A6E0068890D /* THOX509Certificate.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1410,6 +1414,8 @@
 		5D9B8EB7170A0EB400919CB0 /* CleanUpResources.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = CleanUpResources.sh; path = "Main Project (Textual).xcodeproj/CleanUpResources.sh"; sourceTree = SOURCE_ROOT; };
 		5D9B8EB8170A0EB400919CB0 /* UpdateVersionInfo.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = UpdateVersionInfo.sh; path = "Main Project (Textual).xcodeproj/UpdateVersionInfo.sh"; sourceTree = SOURCE_ROOT; };
 		5D9B8EB9170A10F200919CB0 /* BuildExtensions.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = BuildExtensions.sh; path = "Main Project (Textual).xcodeproj/BuildExtensions.sh"; sourceTree = SOURCE_ROOT; };
+		927F2E4A18428A6E0068890D /* THOX509Certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = THOX509Certificate.h; path = ../Helpers/THOX509Certificate.h; sourceTree = "<group>"; };
+		927F2E4B18428A6E0068890D /* THOX509Certificate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = THOX509Certificate.m; path = Helpers/THOX509Certificate.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1936,6 +1942,7 @@
 		4C8AF527158E99520026668C /* Headers */ = {
 			isa = PBXGroup;
 			children = (
+				927F2E4A18428A6E0068890D /* THOX509Certificate.h */,
 				4C8AF73E158EB6CA0026668C /* External Libraries */,
 				4C8AF533158E99520026668C /* IRC.h */,
 				4C8AF534158E99520026668C /* IRCAddressBook.h */,
@@ -2304,6 +2311,7 @@
 				4CBCF89F16C7D0B300DC3521 /* Plugin Architecture */,
 				4C950C0316D6C64300A93D8D /* Threading */,
 				4CB9980817C39E83008F56D7 /* THOUnicodeHelper.m */,
+				927F2E4B18428A6E0068890D /* THOX509Certificate.m */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -2624,6 +2632,7 @@
 				4C1E2BF616FB2483007C9717 /* NSUserDefaultsHelper.h in Headers */,
 				4CB331BE16F1BBE000D65CBE /* NSImageHelper.h in Headers */,
 				4C937BDC17061A3F0050CEF3 /* TLOSpeechSynthesizer.h in Headers */,
+				927F2E4D18428A6E0068890D /* THOX509Certificate.h in Headers */,
 				4C0444E816F1555800EBB665 /* TVCServerListCellBadge.h in Headers */,
 				4C3EB79E17898FD600D21A07 /* TVCLogControllerHistoricLogFile.h in Headers */,
 				5D4846CB171F0ACD0015F2B0 /* OELReachability.h in Headers */,
@@ -2774,6 +2783,7 @@
 				4C1E2BF516FB1F22007C9717 /* NSUserDefaultsHelper.h in Headers */,
 				4C8AF68C158E99520026668C /* TXMenuController.h in Headers */,
 				5D4846CA171F0ACD0015F2B0 /* OELReachability.h in Headers */,
+				927F2E4C18428A6E0068890D /* THOX509Certificate.h in Headers */,
 				4C937BDB170618A80050CEF3 /* TLOSpeechSynthesizer.h in Headers */,
 				4C0444E716F1553C00EBB665 /* TVCServerListCellBadge.h in Headers */,
 				4C5A0317170C2C170016BB1A /* TPCPreferencesImportExport.h in Headers */,
@@ -2855,6 +2865,11 @@
 			attributes = {
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = "Codeux Software";
+				TargetAttributes = {
+					4C1DC5511580420500A47BC9 = {
+						DevelopmentTeam = J8B76VBZ57;
+					};
+				};
 			};
 			buildConfigurationList = 4C1DC54C1580420500A47BC9 /* Build configuration list for PBXProject "Main Project (Textual)" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -3322,6 +3337,7 @@
 				4C0445DF16F1603C00EBB665 /* TVCMainWindowSegmentedControl.m in Sources */,
 				4C0445E016F1603C00EBB665 /* TVCThinSplitView.m in Sources */,
 				4C83D8F01842008D00BCC0E1 /* NSFileManagerHelper.m in Sources */,
+				927F2E4F18428A6E0068890D /* THOX509Certificate.m in Sources */,
 				4CB331B616F1BBC700D65CBE /* NSImageHelper.m in Sources */,
 				4C529E1817AEFE17009BA0B3 /* NSDataHelper.m in Sources */,
 				5D4846C4171F0AC00015F2B0 /* OELReachability.m in Sources */,
@@ -3453,6 +3469,7 @@
 				4C1E2BEF16FB1F13007C9717 /* NSUserDefaultsHelper.m in Sources */,
 				4C937BD5170618940050CEF3 /* TLOSpeechSynthesizer.m in Sources */,
 				4C83D8EF1842008D00BCC0E1 /* NSFileManagerHelper.m in Sources */,
+				927F2E4E18428A6E0068890D /* THOX509Certificate.m in Sources */,
 				4C5A0311170C2C010016BB1A /* TPCPreferencesImportExport.m in Sources */,
 				4C529E1717AEFE17009BA0B3 /* NSDataHelper.m in Sources */,
 				5D4846C3171F0AC00015F2B0 /* OELReachability.m in Sources */,
@@ -3739,24 +3756,30 @@
 		4C1DC5711580420500A47BC9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SYSTEM_LIBRARY_DIR)/Frameworks/Quartz.framework/Versions/A/Frameworks\"",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				PROVISIONING_PROFILE = "";
 			};
 			name = Debug;
 		};
 		4C1DC5721580420500A47BC9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SYSTEM_LIBRARY_DIR)/Frameworks/Quartz.framework/Versions/A/Frameworks\"",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				PROVISIONING_PROFILE = "";
 			};
 			name = Release;
 		};
@@ -3814,12 +3837,15 @@
 		4C77A3261748BCDC00D9BD05 /* Release (Trial) */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SYSTEM_LIBRARY_DIR)/Frameworks/Quartz.framework/Versions/A/Frameworks\"",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				PROVISIONING_PROFILE = "";
 			};
 			name = "Release (Trial)";
 		};
@@ -3879,12 +3905,15 @@
 		4CCF2F9115804987006FFE21 /* Release (App Store) */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SYSTEM_LIBRARY_DIR)/Frameworks/Quartz.framework/Versions/A/Frameworks\"",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				PROVISIONING_PROFILE = "";
 			};
 			name = "Release (App Store)";
 		};


### PR DESCRIPTION
There is already a dialog/sheet to ask the user a confirmation when connecting
to an IRC server with self-signed/untrusted certificate, but this patch extends
it to display certificate information to allow the user to make a more informed
decision.

Would Codeux be interested in that kind of contribution?
