### PR TITLE
Enables the Standard suite of AppleScript commands

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -76,6 +76,8 @@
 	<string>public.app-category.social-networking</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.7.3</string>
+	<key>NSAppleScriptEnabled</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2010 — 2013 Codeux Software</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
A user came to #textual today asking about [Layouts](http://projects.jga.me/layouts/) compatibility with Textual.
This uses a few of the window-related verbs in the Standard suite, but Textual was not enabled for even these rudimentary verbs.

Of course this does not allow for any Textual-specific AppleScript commands, but these window commands require no further changes to the code to enable some useful features.
