### PR TITLE
Embedded images with query params will not embed and any chunked image will not embed due to the sizeInBytes not being available.

### DIFF
--- a/Classes/Views/Channel View/TVCImageURLParser.m
+++ b/Classes/Views/Channel View/TVCImageURLParser.m
@@ -54,6 +54,11 @@
 	
 	NSString *host = [u.host lowercaseString];
 	NSString *path = [u.path encodeURIFragment];
+	NSString *query = [u.query encodeURIFragment];
+    
+    if (query != nil){
+        path = [[path stringByAppendingString:@"?"] stringByAppendingString:query];
+    }
 
 	if ([scheme isEqualToString:@"file"]) {
 		// If the file is a local file (file:// scheme), then let us ignore it.

--- a/Classes/Views/Channel View/TVCImageURLoader.m
+++ b/Classes/Views/Channel View/TVCImageURLoader.m
@@ -123,7 +123,7 @@
 	NSString *imageContentType = [headers stringForKey:@"Content-Type"];
 
 	/* Check size. */
-	if (sizeInBytes > [TPCPreferences inlineImagesMaxFilesize] || sizeInBytes < 10) {
+	if (sizeInBytes > [TPCPreferences inlineImagesMaxFilesize] || sizeInBytes < 0) {
 		return NO;
 	}
 


### PR DESCRIPTION
Embedded images with query params will not embed and any chunked image will not embed due to the sizeInBytes not being available.

Example URL with both issues:

http://stockcharts.com/c-sc/sc?s=aapl&p=D&b=5&g=0&i=0&r=5924&.png

Updated code to handle example URL/image for embedding.
