### PR TITLE
Detect message from ZNC's privmsg module and behave gracefully

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -3616,6 +3616,15 @@
 	
 	NSString *sender = m.sender.nickname;
 	NSString *target = [m paramAt:0];
+    
+	BOOL isZNCprivmsg = NO;
+	
+	if (self.isZNCBouncerConnection == YES) {
+		/* Detect privmsg module messages */
+		if ([sender isEqualToString:self.myNick]) {
+			isZNCprivmsg = YES;
+		}
+	}
 	
 	BOOL isEncrypted = NO;
 
@@ -3759,7 +3768,12 @@
 			}
 
 			/* Does the query for the sender already exist?… */
-			IRCChannel *c = [self findChannel:sender];
+			IRCChannel *c;
+			if (isZNCprivmsg == YES) {
+				c = [self findChannel:target];
+			} else {
+				c = [self findChannel:sender];
+			}
 
 			BOOL newPrivateMessage = NO;
 


### PR DESCRIPTION
I'm using the (third party) ZNC "privmsg" module from http://wiki.znc.in/Privmsg and noticed that Textual doesn't detect its messages and behave appropriately (although the wiki page suggests that it has done so in the past).

This is a first run at implementing it - seems like a fairly simple fix and some light testing suggests it works, but I wanted to request some feedback before I dig further.
