### PR TITLE
Update HostServ Syntax to be valid with latest atheme-services GIT

### DIFF
--- a/Classes/Controllers/TXMenuController.m
+++ b/Classes/Controllers/TXMenuController.m
@@ -2147,7 +2147,7 @@
 	NSArray *nicknames = [self selectedMembers:sender];
 	
 	for (IRCUser *m in nicknames) {
-		[u sendCommand:[NSString stringWithFormat:@"hs setall %@ %@", m.nickname, vhost] completeTarget:NO target:nil];
+		[u sendCommand:[NSString stringWithFormat:@"hs vhost %@ %@", m.nickname, vhost] completeTarget:NO target:nil];
 	}
 
 	[self deselectMembers:sender];


### PR DESCRIPTION
The HostServ Syntax of atheme is
`/hs VHOST <nickname> [<vHost>]`
If `<vHost>` isn't given, the vHost will be removed.
