### PR TITLE
Adds 'You're now known as' for nick change.

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -4446,8 +4446,19 @@
 		IRCChannel *c = [self findChannel:target];
 
 		if (c) {
-			if ((myself == NO && [ignoreChecks ignoreJPQE] == NO && [TPCPreferences showJoinLeave] && c.config.ignoreJPQActivity == NO) || myself == YES) {
-				NSString *text = TXTFLS(@"BasicLanguage[1152]", oldNick, newNick);
+			if ((myself == NO && [ignoreChecks ignoreJPQE] == NO && [TPCPreferences showJoinLeave] && c.config.ignoreJPQActivity == NO)) {
+				NSString *text = TXTFLS(@"BasicLanguage[1152][0]", oldNick, newNick);
+
+				[self print:c
+					   type:TVCLogLineNickType
+					   nick:nil
+					   text:text
+				 receivedAt:m.receivedAt
+					command:m.command];
+			}
+            
+			if (myself == YES) {
+				NSString *text = TXTFLS(@"BasicLanguage[1152][1]", newNick);
 
 				[self print:c
 					   type:TVCLogLineNickType
@@ -4467,8 +4478,19 @@
 	for (IRCChannel *c in self.channels) {
 		if ([c memberWithNickname:oldNick]) {
             
-			if ((myself == NO && [ignoreChecks ignoreJPQE] == NO && [TPCPreferences showJoinLeave] && c.config.ignoreJPQActivity == NO) || myself == YES) {
-				NSString *text = TXTFLS(@"BasicLanguage[1152]", oldNick, newNick);
+			if ((myself == NO && [ignoreChecks ignoreJPQE] == NO && [TPCPreferences showJoinLeave] && c.config.ignoreJPQActivity == NO)) {
+				NSString *text = TXTFLS(@"BasicLanguage[1152][0]", oldNick, newNick);
+
+				[self print:c
+					   type:TVCLogLineNickType
+					   nick:nil
+					   text:text
+				 receivedAt:m.receivedAt
+					command:m.command];
+			}
+            
+			if (myself == YES) {
+				NSString *text = TXTFLS(@"BasicLanguage[1152][1]", newNick);
 
 				[self print:c
 					   type:TVCLogLineNickType

--- a/Resources/Localization/English.lproj/BasicLanguage.strings
+++ b/Resources/Localization/English.lproj/BasicLanguage.strings
@@ -394,7 +394,8 @@
 "BasicLanguage[1149]" = "Netsplit: %@";
 "BasicLanguage[1150]" = "%1$@ (%2$@)";
 "BasicLanguage[1151]" = "%@ IRC Network";
-"BasicLanguage[1152]" = "%1$@ is now known as \002%2$@\002";
+"BasicLanguage[1152][0]" = "%1$@ is now known as \002%2$@\002";
+"BasicLanguage[1152][1]" = "You're now known as \002%2$@\002";
 "BasicLanguage[1153]" = "\002%1$@\002 (%2$@@%3$@) left IRC.";
 "BasicLanguage[1154]" = "\002%1$@\002 left the query by disconnecting from IRC.";
 "BasicLanguage[1155]" = "\002%1$@\002 joined the query by connecting to IRC.";


### PR DESCRIPTION
This adds a more elaborate notification about nick change.

If, for instance, a nick-change was forced by the _bnc_ and other users with extremely similar names exists in the channel, a user might not notice that his nick has been changed.

Previous:

```
[12:09:51]   user is now known as apx`
[12:09:54]   user2 is now known as `apx
[12:09:58]   apx (<= local user) is now known as apx_
[12:09:59]   user3 is now known as `apx`
```

Now:

```
[12:09:51]   user is now known as apx`
[12:09:54]   user2 is now known as `apx
[12:09:58]   You're now known as apx_
[12:09:59]   user3 is now known as `apx`
```

Cheers
