### PR TITLE
Fix 'Topic is...'

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -5290,7 +5290,7 @@
 				[self print:c
 					   type:TVCLogLineTopicType
 					   nick:nil
-					   text:TXTFLS(@"BasicLanguage[1123]", topicva)
+					   text:TXTFLS(@"BasicLanguage[1124]", topicva)
 				  encrypted:isEncrypted
 				 receivedAt:m.receivedAt
 					command:m.command];


### PR DESCRIPTION
Steps to reproduce:
1. Join a channel with a topic set.

Effect:
It says "Mode is..." instead of "Topic is..."
