### PR TITLE
Fix nil usage in dictionary warnings

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -2660,7 +2660,7 @@
 			/* Scan scripts first. */
 			NSDictionary *scriptPaths = [THOPluginManagerSharedInstance() supportedAppleScriptCommands:YES];
 
-			NSString *scriptPath;
+			NSString *scriptPath = @"";
 
 			for (NSString *scriptCommand in scriptPaths) {
 				if ([scriptCommand isEqualToString:lowercaseCommand]) {

--- a/Classes/Views/Channel View/TVCLogController.m
+++ b/Classes/Views/Channel View/TVCLogController.m
@@ -1267,8 +1267,8 @@
 		templateTokens[@"channelName"]	  = [TVCLogRenderer escapeString:[[self channel] name]];
 		templateTokens[@"viewTypeToken"]  = [[self channel] channelTypeString];
 
-		if (NSObjectIsEmpty(topic)) {
-			templateTokens[@"formattedTopicValue"] = TXTLS(@"BasicLanguage[1122]");
+		if (topic == nil || NSObjectIsEmpty(topic)) {
+			templateTokens[@"formattedTopicValue"] = TXTLS(@"BasicLanguage[1122]")	;
 		} else {
 			templateTokens[@"formattedTopicValue"] = topic;
 		}


### PR DESCRIPTION
Two warnings:
The first, |scriptPath| is being used in a dictionary and it can be nil:
   /Users/dougt/builds/Textual/Classes/IRC/IRCClient.m:2686:33: Dictionary value cannot be nil

The second, NSObjectIsEmpty(topic) (according to the compiler) can return true if topic is nil.
    /Users/dougt/builds/Textual/Classes/Views/Channel View/TVCLogController.m:1273:4: Value stored into 'NSMutableDictionary' cannot be nil
