### PR TITLE
Fix duplicated string entry which caused folder select dialogs to show incorrect button label

### DIFF
--- a/Classes/Headers/TDCPreferencesSoundWrapper.h
+++ b/Classes/Headers/TDCPreferencesSoundWrapper.h
@@ -38,7 +38,7 @@
 
 #import "TextualApplication.h"
 
-#define TXEmptySoundAlertLabel			TXTLS(@"BasicLanguage[1225]")
+#define TXEmptySoundAlertLabel			TXTLS(@"BasicLanguage[1234]")
 #define TXEmptySoundAlertPreference		@"None"
 
 @interface TDCPreferencesSoundWrapper : NSObject

--- a/Resources/Localization/English.lproj/BasicLanguage.strings
+++ b/Resources/Localization/English.lproj/BasicLanguage.strings
@@ -565,9 +565,6 @@
 /* Selet button for dialogs. */
 "BasicLanguage[1225]" = "Select";
 
-/* Empty alert sound label. */
-"BasicLanguage[1225]" = "None";
-
 /* /tage/ command. */
 "BasicLanguage[1226]" = "\002Time Since First Commit:\002 %@";
 
@@ -599,3 +596,6 @@
 "BasicLanguage[1233][1]" = "Connect";
 "BasicLanguage[1233][2]" = "Connect using IPv4";
 "BasicLanguage[1233][3]" = "Connect using IPv6";
+
+/* Empty alert sound label. */
+"BasicLanguage[1234]" = "None";


### PR DESCRIPTION
BasicLanguage[1225] occurred twice, which resulted in instances of
"Select" being overwritten with "None" for the select button on some
folder selection dialog boxes. This creates a new BasicLanguage[1234]
for the "None" entry and updates the references to that string,
which fixes the button on the folder selection dialog boxes.
