### PR TITLE
Increase TXMaximumIRCUsernameLength from 20 to 40.

### DIFF
--- a/Classes/Headers/IRC.h
+++ b/Classes/Headers/IRC.h
@@ -40,7 +40,7 @@
 /* Hard limits. */
 #define TXMaximumIRCBodyLength				512
 #define TXMaximumIRCNicknameLength			50
-#define TXMaximumIRCUsernameLength			20
+#define TXMaximumIRCUsernameLength			40
 #define TXMaximumNodesPerModeCommand		4
 
 /* Command index. */


### PR DESCRIPTION
This will fix issues for bitlbee users who connect to xmpp servers that generate long usernames.
