### PR TITLE
Adding GeeksIRC to the network list

### DIFF
--- a/Resources/Miscellaneous/IRCNetworks.plist
+++ b/Resources/Miscellaneous/IRCNetworks.plist
@@ -16,6 +16,8 @@
 	<string>irc.flux.cd</string>
 	<key>freenode</key>
 	<string>chat.freenode.net</string>
+	<key>GeeksIRC</key>
+	<string>irc.geeksirc.net</string>
 	<key>GameSurge</key>
 	<string>irc.gamesurge.net</string>
 	<key>German-Elite</key>


### PR DESCRIPTION
GeeksIRC is an open-topic network which averages around ~150 users
