### PR TITLE
Update close button to use multiplication sign

### DIFF
--- a/Resources/Styles/Style Default Templates/Version 2/newMessagePostedWithSender.mustache
+++ b/Resources/Styles/Style Default Templates/Version 2/newMessagePostedWithSender.mustache
@@ -40,7 +40,7 @@
 						{{#inlineMediaArray}}
 
 						<span class="inlineImageCell" id="inlineImage-{{anchorInlineImageUniqueID}}" style="display: none;">
-							<a class="closeButton" href="#" onclick="Textual.toggleInlineImage('{{anchorInlineImageUniqueID}}', false); return false;">x</a>
+							<a class="closeButton" href="#" onclick="Textual.toggleInlineImage('{{anchorInlineImageUniqueID}}', false); return false;">×</a>
 
 							<a href="{{{anchorLink}}}" onclick="return InlineImageLiveResize.negateAnchorOpen()">
 								<img src="{{{imageURL}}}" class="image" style="max-width: {{preferredMaximumWidth}}px;" />


### PR DESCRIPTION
The multiplication sign is designed to have equal-length strokes and centers between the baseline and cap line rather than straddling the span from the baseline to the median (which is rarely center). It's also far less subject to the vagaries of fonts (serifs, weird metrics, and such).
