### PR TITLE
Add missing iCloud #ifdef in theme controller post-refactor

### DIFF
--- a/Classes/Dialogs/Preferences/TDCPreferencesController.m
+++ b/Classes/Dialogs/Preferences/TDCPreferencesController.m
@@ -232,7 +232,7 @@
 								   name:TPCThemeControllerThemeListDidChangeNotification
 								 object:nil];
 	
-#ifdef TEXTUAL_BUILT_WITH_ICLOUD_SUPPORTs
+#ifdef TEXTUAL_BUILT_WITH_ICLOUD_SUPPORT
 	[RZNotificationCenter() addObserver:self
 							   selector:@selector(onCloudSyncControllerDidChangeThemeName:)
 								   name:TPCPreferencesCloudSyncDidChangeGlobalThemeNamePreferenceNotification

--- a/Classes/Preferences/Themes/TPCThemeController.m
+++ b/Classes/Preferences/Themes/TPCThemeController.m
@@ -595,7 +595,10 @@ void activeThemePathMonitorCallback(ConstFSEventStreamRef streamRef,
 						if ([[copyOperation themeName] isEqual:nameFromPath]) {
 							NSString *pathWithoutName = [path stringByDeletingLastPathComponent];
 							
-							if (([copyOperation destinationLocation] == TPCThemeControllerStorageCloudLocation && [pathWithoutName isEqual:[TPCPathInfo cloudCustomThemeCachedFolderPath]]) ||
+							if (
+#ifdef TEXTUAL_BUILT_WITH_ICLOUD_SUPPORT
+                                ([copyOperation destinationLocation] == TPCThemeControllerStorageCloudLocation && [pathWithoutName isEqual:[TPCPathInfo cloudCustomThemeCachedFolderPath]]) ||
+#endif
 								([copyOperation destinationLocation] == TPCThemeControllerStorageCustomLocation && [pathWithoutName isEqual:[TPCPathInfo customThemeFolderPath]]))
 							{
 								[copyOperation endOperation];


### PR DESCRIPTION
Textual was refusing to compile after the theme controller refactor. This allowed the build to finish, and the resulting app package is running fine so far.
