### PR TITLE
Fix topic bar in OS X 10.10 Yosemite

### DIFF
--- a/Resources/Styles/Style Default Templates/Version 2/baseLayout.mustache
+++ b/Resources/Styles/Style Default Templates/Version 2/baseLayout.mustache
@@ -3,9 +3,9 @@
 		{{#isChannelView}}
 			channelname="{{channelName}}" 
 		{{/isChannelView}}
-        
+
 		{{#isPrivateMessageView}}
-			channelname="{{channelName}}" 
+			channelname="{{channelName}}"
 		{{/isPrivateMessageView}}
 
 		{{! The operating system version declaration allows CSS selectors to target specific versions. }}
@@ -14,26 +14,26 @@
 		dir="{{textDirectionToken}}">
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset={{userConfiguredTextEncoding}}">
-		
+
 		<link rel="stylesheet" type="text/css" href="{{activeStyleAbsolutePath}}design.css?u={{cacheToken}}">
-		
+
 		<script src="{{applicationResourcePath}}/JavaScript/API/core.js" type="text/javascript"></script>
 		<script src="{{applicationResourcePath}}/JavaScript/API/corePrivate.js" type="text/javascript"></script>
 		<script src="{{applicationResourcePath}}/JavaScript/API/liveresize.js" type="text/javascript"></script>
 		<script src="{{activeStyleAbsolutePath}}scripts.js?u={{cacheToken}}" type="text/javascript"></script>
-		
+
 		<style type="text/css">
 			html, body, body[type], body {
 				font-family: '{{userConfiguredFontName}}';
 				font-size: {{userConfiguredFontSize}}pt;
 			}
-			
+
 			{{#nicknameIndentationAvailable}}
 				body div#body_home p {
 					margin-left: {{predefinedTimestampWidth}}px;
 					text-indent: -{{predefinedTimestampWidth}}px;
 				}
-			
+
 				body .time {
 					width: {{predefinedTimestampWidth}}px;
 				}
@@ -41,9 +41,9 @@
 
 			{{!
 				The following CSS definitions exist for the internal use of Textual.
-				If you are a style developer reading this and plan on using custom 
+				If you are a style developer reading this and plan on using custom
 				templates, then DO NOT modify these. You can touch anything else you
-				want, but we are trying to have some consistency between styles. 
+				want, but we are trying to have some consistency between styles.
 			}}
 
 			/* Print actions. */
@@ -94,29 +94,32 @@
 			.effect[bgcolor-number='15'] { background-color: #cccccc; }
 		</style>
 	</head>
-	
+
 	<body viewtype="{{viewTypeToken}}"
-	
+
 		onload="Textual.viewBodyDidLoad()"
 
 		{{#isChannelView}}
-			channelname="{{channelName}}" 
+			channelname="{{channelName}}"
 		{{/isChannelView}}
-        
+
 		{{#isPrivateMessageView}}
-			channelname="{{channelName}}" 
+			channelname="{{channelName}}"
 		{{/isPrivateMessageView}}
-		
+
 		dir="{{textDirectionToken}}">
-			{{! The elements "body_home," "loading_screen," "topic_bar," and "mark" must always 
+			{{! The elements "body_home," "loading_screen," "topic_bar," and "mark" must always
 			    remain the same as the ID value of these elements are used internally by Textual. }}
-			
+
 			<div id="loading_screen">View is Loading…</div>
-			<div id="body_home">{{! Filled at runtime. }}</div>
-		
-			{{#isChannelView}}
-				<div id="topic_bar"
-ondblclick="Textual.topicDoubleClicked()">{{{formattedTopicValue}}}</div>
-			{{/isChannelView}}
+
+			<div id="body_container">
+				<div id="body_home">{{! Filled at runtime. }}</div>
+
+				{{#isChannelView}}
+					<div id="topic_bar"
+					ondblclick="Textual.topicDoubleClicked()">{{{formattedTopicValue}}}</div>
+				{{/isChannelView}}
+			</div>
 	</body>
 </html>

--- a/Resources/Styles/Styles/Astria/design.css
+++ b/Resources/Styles/Styles/Astria/design.css
@@ -5,23 +5,28 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
-}	
+	overflow: hidden;
+}
 
 body {
 	color: #fff;
 	height: 100%;
  	z-index: 100;
 	font-size: 9px;
-	overflow: hidden;
-	overflow-y: visible;
 	background-color: #000;
 	font-family: "Lucida Grande";
 }
 
+body div#body_container {
+	height: 100%;
+}
+
 body div#body_home {
+	overflow-y: scroll;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	top: 0;
 	width: 100%;
 	z-index: 100;
 	max-height: 99.99%;
@@ -46,7 +51,7 @@ body[dir=rtl] .sender {
 /* Loading Screen */
 
 body div#loading_screen {
-	position:absolute; 
+	position:absolute;
 	top: 50%;
 	left: 50%;
 	margin-top: -11px;
@@ -67,12 +72,12 @@ body div#loading_screen {
 
 body[dir=ltr] .time {
 	color: #ffffff;
-	white-space: nowrap; 
+	white-space: nowrap;
 }
 
 body[dir=rtl] .time {
 	color: #ffffff;
-	white-space: nowrap; 
+	white-space: nowrap;
 	padding-left: 0.4em;
 	display: inline-block;
 }
@@ -111,7 +116,7 @@ a:hover {
 	color: #fff;
 	z-index: 400;
 	opacity: 0; /* Set by JavaScript */
-	position: fixed;
+	position: absolute;
 	background: #000;
 	padding: 2px 0.5em 3px;
 	border-bottom: 1px solid #1f1f1f;
@@ -197,7 +202,7 @@ div[id=mark] {
 
 /* Historic Line */
 
-.historic 
+.historic
 {
 	opacity: 0.6;
 }
@@ -350,7 +355,7 @@ body div.line[ltype*=dccfiletransfer] {
 
 /* Message of the Day (MOTD) */
 /* 720, 721, 722 are used by ShadowIRCd for Oper MOTD. */
-/* 372, 375, 376 are normal MOTD shared by several IRCds. */ 
+/* 372, 375, 376 are normal MOTD shared by several IRCds. */
 
 body div.line[command="372"],
 body div.line[command="721"] {
@@ -375,7 +380,7 @@ body div.line[command="722"] { /* End. */
 
 body div.line[command="372"] .message,
 body div.line[command="375"] .message,
-body div.line[command="376"] .message 
+body div.line[command="376"] .message
 body div.line[command="720"] .message,
 body div.line[command="721"] .message,
 body div.line[command="722"] .message {
@@ -547,161 +552,161 @@ body .inline_nickname {
 	font-weight: 700;
 }
 
-body div[ltype*=privmsg] .sender[mtype*=myself] { 
-	color: #B8DFFF; 
+body div[ltype*=privmsg] .sender[mtype*=myself] {
+	color: #B8DFFF;
 }
 
-body .sender[mtype*=normal][colornumber='0'], 
+body .sender[mtype*=normal][colornumber='0'],
 body .inline_nickname[colornumber='0'] {
-	color: #cb5d5a; 
+	color: #cb5d5a;
 }
 
-body .sender[mtype*=normal][colornumber='1'], 
+body .sender[mtype*=normal][colornumber='1'],
 body .inline_nickname[colornumber='1'] {
-	color: #a3bf75; 
+	color: #a3bf75;
 }
 
-body .sender[mtype*=normal][colornumber='2'], 
+body .sender[mtype*=normal][colornumber='2'],
 body .inline_nickname[colornumber='2'] {
-	color: #9b85b3; 
+	color: #9b85b3;
 }
 
-body .sender[mtype*=normal][colornumber='3'], 
+body .sender[mtype*=normal][colornumber='3'],
 body .inline_nickname[colornumber='3'] {
-	color: #C083F2; 
+	color: #C083F2;
 }
 
-body .sender[mtype*=normal][colornumber='4'], 
+body .sender[mtype*=normal][colornumber='4'],
 body .inline_nickname[colornumber='4'] {
-	color: #8bd3e5; 
+	color: #8bd3e5;
 }
 
-body .sender[mtype*=normal][colornumber='5'], 
+body .sender[mtype*=normal][colornumber='5'],
 body .inline_nickname[colornumber='5'] {
-	color: #f4a36c; 
+	color: #f4a36c;
 }
 
-body .sender[mtype*=normal][colornumber='6'], 
+body .sender[mtype*=normal][colornumber='6'],
 body .inline_nickname[colornumber='6'] {
-	color: #75ade1; 
+	color: #75ade1;
 }
 
-body .sender[mtype*=normal][colornumber='7'], 
+body .sender[mtype*=normal][colornumber='7'],
 body .inline_nickname[colornumber='7'] {
-	color: #ffbfbd; 
+	color: #ffbfbd;
 }
 
-body .sender[mtype*=normal][colornumber='8'], 
+body .sender[mtype*=normal][colornumber='8'],
 body .inline_nickname[colornumber='8'] {
-	color: #b2cc00; 
+	color: #b2cc00;
 }
 
-body .sender[mtype*=normal][colornumber='9'], 
+body .sender[mtype*=normal][colornumber='9'],
 body .inline_nickname[colornumber='9'] {
-	color: #96ff00; 
+	color: #96ff00;
 }
 
-body .sender[mtype*=normal][colornumber='10'], 
+body .sender[mtype*=normal][colornumber='10'],
 body .inline_nickname[colornumber='10'] {
-	color: #05ffaa; 
+	color: #05ffaa;
 }
 
-body .sender[mtype*=normal][colornumber='11'], 
+body .sender[mtype*=normal][colornumber='11'],
 body .inline_nickname[colornumber='11'] {
-	color: #ffe982; 
+	color: #ffe982;
 }
 
-body .sender[mtype*=normal][colornumber='12'], 
+body .sender[mtype*=normal][colornumber='12'],
 body .inline_nickname[colornumber='12'] {
-	color: #aadeff; 
+	color: #aadeff;
 }
 
-body .sender[mtype*=normal][colornumber='13'], 
+body .sender[mtype*=normal][colornumber='13'],
 body .inline_nickname[colornumber='13'] {
-	color: #36ff15; 
+	color: #36ff15;
 }
 
-body .sender[mtype*=normal][colornumber='14'], 
+body .sender[mtype*=normal][colornumber='14'],
 body .inline_nickname[colornumber='14'] {
-	color: #ff6076; 
+	color: #ff6076;
 }
 
-body .sender[mtype*=normal][colornumber='15'], 
+body .sender[mtype*=normal][colornumber='15'],
 body .inline_nickname[colornumber='15'] {
-	color: #8e908f; 
+	color: #8e908f;
 }
 
-body .sender[mtype*=normal][colornumber='16'], 
-body .inline_nickname[colornumber='16'] { 
+body .sender[mtype*=normal][colornumber='16'],
+body .inline_nickname[colornumber='16'] {
 	color: #706616;
 }
 
-body .sender[mtype*=normal][colornumber='17'], 
-body .inline_nickname[colornumber='17'] { 
+body .sender[mtype*=normal][colornumber='17'],
+body .inline_nickname[colornumber='17'] {
 	color: #46799c;
 }
 
-body .sender[mtype*=normal][colornumber='18'], 
-body .inline_nickname[colornumber='18'] { 
+body .sender[mtype*=normal][colornumber='18'],
+body .inline_nickname[colornumber='18'] {
 	color: #80372e;
 }
 
-body .sender[mtype*=normal][colornumber='19'], 
-body .inline_nickname[colornumber='19'] { 
+body .sender[mtype*=normal][colornumber='19'],
+body .inline_nickname[colornumber='19'] {
 	color: #8F478E;
 }
 
-body .sender[mtype*=normal][colornumber='20'], 
-body .inline_nickname[colornumber='20'] { 
+body .sender[mtype*=normal][colornumber='20'],
+body .inline_nickname[colornumber='20'] {
 	color: #5b9e4c;
 }
 
-body .sender[mtype*=normal][colornumber='21'], 
-body .inline_nickname[colornumber='21'] { 
+body .sender[mtype*=normal][colornumber='21'],
+body .inline_nickname[colornumber='21'] {
 	color: #13826c;
 }
 
-body .sender[mtype*=normal][colornumber='22'], 
-body .inline_nickname[colornumber='22'] { 
+body .sender[mtype*=normal][colornumber='22'],
+body .inline_nickname[colornumber='22'] {
 	color: #b13637;
 }
 
-body .sender[mtype*=normal][colornumber='23'], 
-body .inline_nickname[colornumber='23'] { 
+body .sender[mtype*=normal][colornumber='23'],
+body .inline_nickname[colornumber='23'] {
 	color: #e45d59;
 }
 
-body .sender[mtype*=normal][colornumber='24'], 
-body .inline_nickname[colornumber='24'] { 
+body .sender[mtype*=normal][colornumber='24'],
+body .inline_nickname[colornumber='24'] {
 	color: #1b51ae;
 }
 
-body .sender[mtype*=normal][colornumber='25'], 
-body .inline_nickname[colornumber='25'] { 
+body .sender[mtype*=normal][colornumber='25'],
+body .inline_nickname[colornumber='25'] {
 	color: #4855ac;
 }
 
-body .sender[mtype*=normal][colornumber='26'], 
-body .inline_nickname[colornumber='26'] { 
+body .sender[mtype*=normal][colornumber='26'],
+body .inline_nickname[colornumber='26'] {
 	color: #7f1d86;
 }
 
-body .sender[mtype*=normal][colornumber='27'], 
-body .inline_nickname[colornumber='27'] { 
+body .sender[mtype*=normal][colornumber='27'],
+body .inline_nickname[colornumber='27'] {
 	color: #73643f;
 }
 
-body .sender[mtype*=normal][colornumber='28'], 
-body .inline_nickname[colornumber='28'] { 
+body .sender[mtype*=normal][colornumber='28'],
+body .inline_nickname[colornumber='28'] {
 	color: #0b9578;
 }
 
-body .sender[mtype*=normal][colornumber='29'], 
-body .inline_nickname[colornumber='29'] { 
+body .sender[mtype*=normal][colornumber='29'],
+body .inline_nickname[colornumber='29'] {
 	color: #569c96;
 }
 
-body .sender[mtype*=normal][colornumber='30'], 
-body .inline_nickname[colornumber='30'] { 
+body .sender[mtype*=normal][colornumber='30'],
+body .inline_nickname[colornumber='30'] {
 	color: #08465f;
 }

--- a/Resources/Styles/Styles/Sapientia/design.css
+++ b/Resources/Styles/Styles/Sapientia/design.css
@@ -5,23 +5,28 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
-}	
+	overflow: hidden;
+}
 
 body {
 	color: #E8E7E3;
 	height: 100%;
  	z-index: 100;
 	font-size: 15pt;
-	overflow: hidden;
-	overflow-y: visible;
 	background-color: #242323;
 	font-family: "HelveticaNeue";
 }
 
+body div#body_container {
+	height: 100%;
+}
+
 body div#body_home {
+	overflow-y: scroll;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	top: 0;
 	width: 100%;
 	z-index: 100;
 	max-height: 99.99%;
@@ -46,7 +51,7 @@ body[dir=rtl] .sender {
 /* Loading Screen */
 
 body div#loading_screen {
-	position:absolute; 
+	position:absolute;
 	top: 50%;
 	left: 50%;
 	margin-top: -11px;
@@ -67,12 +72,12 @@ body div#loading_screen {
 
 body[dir=ltr] .time {
 	color: #343434;
-	white-space: nowrap; 
+	white-space: nowrap;
 }
 
 body[dir=rtl] .time {
 	color: #343434;
-	white-space: nowrap; 
+	white-space: nowrap;
 	padding-left: 0.4em;
 	display: inline-block;
 }
@@ -112,7 +117,7 @@ a:hover {
 	z-index: 400;
 	opacity: 0; /* Set by JavaScript */
 	line-height: 145%;
-	position: fixed;
+	position: absolute;
 	background: -webkit-linear-gradient(top, #494949 0%, #282828 100%);
 	padding: 2px 0.5em 3px;
 	border-bottom: 1px solid #544E45;
@@ -196,7 +201,7 @@ div[id=mark] {
 
 /* Historic Line */
 
-.historic 
+.historic
 {
 	opacity: 0.6;
 }
@@ -345,7 +350,7 @@ body div.line[ltype*=dccfiletransfer] {
 
 /* Message of the Day (MOTD) */
 /* 720, 721, 722 are used by ShadowIRCd for Oper MOTD. */
-/* 372, 375, 376 are normal MOTD shared by several IRCds. */ 
+/* 372, 375, 376 are normal MOTD shared by several IRCds. */
 
 body div.line[command="372"],
 body div.line[command="721"] {
@@ -370,7 +375,7 @@ body div.line[command="722"] { /* End. */
 
 body div.line[command="372"] .message,
 body div.line[command="375"] .message,
-body div.line[command="376"] .message 
+body div.line[command="376"] .message
 body div.line[command="720"] .message,
 body div.line[command="721"] .message,
 body div.line[command="722"] .message {
@@ -438,161 +443,161 @@ body .inline_nickname {
 	font-weight: 700;
 }
 
-body div[ltype*=privmsg] .sender[mtype*=myself] { 
-	color: #A9A9A9; 
+body div[ltype*=privmsg] .sender[mtype*=myself] {
+	color: #A9A9A9;
 }
 
-body .sender[mtype*=normal][colornumber='0'], 
-body .inline_nickname[colornumber='0'] { 
-	color: #D93826; 
+body .sender[mtype*=normal][colornumber='0'],
+body .inline_nickname[colornumber='0'] {
+	color: #D93826;
 }
 
-body .sender[mtype*=normal][colornumber='1'], 
-body .inline_nickname[colornumber='1'] { 
-	color: #636aff; 
+body .sender[mtype*=normal][colornumber='1'],
+body .inline_nickname[colornumber='1'] {
+	color: #636aff;
 }
 
-body .sender[mtype*=normal][colornumber='2'], 
-body .inline_nickname[colornumber='2'] { 
-	color: #00BA00; 
+body .sender[mtype*=normal][colornumber='2'],
+body .inline_nickname[colornumber='2'] {
+	color: #00BA00;
 }
 
-body .sender[mtype*=normal][colornumber='3'], 
-body .inline_nickname[colornumber='3'] { 
-	color: #C083F2; 
+body .sender[mtype*=normal][colornumber='3'],
+body .inline_nickname[colornumber='3'] {
+	color: #C083F2;
 }
 
-body .sender[mtype*=normal][colornumber='4'], 
-body .inline_nickname[colornumber='4'] { 
-	color: #4DEDF0; 
+body .sender[mtype*=normal][colornumber='4'],
+body .inline_nickname[colornumber='4'] {
+	color: #4DEDF0;
 }
 
-body .sender[mtype*=normal][colornumber='5'], 
-body .inline_nickname[colornumber='5'] { 
-	color: #E422B2; 
+body .sender[mtype*=normal][colornumber='5'],
+body .inline_nickname[colornumber='5'] {
+	color: #E422B2;
 }
 
 body .sender[mtype*=normal][colornumber='6'],
-body .inline_nickname[colornumber='6'] { 
-	color: #EAE87E; 
+body .inline_nickname[colornumber='6'] {
+	color: #EAE87E;
 }
 
-body .sender[mtype*=normal][colornumber='7'], 
-body .inline_nickname[colornumber='7'] { 
-	color: #B8DFFF; 
+body .sender[mtype*=normal][colornumber='7'],
+body .inline_nickname[colornumber='7'] {
+	color: #B8DFFF;
 }
 
 body .sender[mtype*=normal][colornumber='8'],
-body .inline_nickname[colornumber='8'] { 
-	color: #75A1FB; 
+body .inline_nickname[colornumber='8'] {
+	color: #75A1FB;
 }
 
-body .sender[mtype*=normal][colornumber='9'], 
-body .inline_nickname[colornumber='9'] { 
-	color: #97C74B; 
+body .sender[mtype*=normal][colornumber='9'],
+body .inline_nickname[colornumber='9'] {
+	color: #97C74B;
 }
 
-body .sender[mtype*=normal][colornumber='10'], 
-body .inline_nickname[colornumber='10'] { 
-	color: #A5EAC4; 
+body .sender[mtype*=normal][colornumber='10'],
+body .inline_nickname[colornumber='10'] {
+	color: #A5EAC4;
 }
 
-body .sender[mtype*=normal][colornumber='11'], 
-body .inline_nickname[colornumber='11'] { 
-	color: #FFA6A0; 
+body .sender[mtype*=normal][colornumber='11'],
+body .inline_nickname[colornumber='11'] {
+	color: #FFA6A0;
 }
 
-body .sender[mtype*=normal][colornumber='12'], 
-body .inline_nickname[colornumber='12'] { 
-	color: #8E67E7; 
+body .sender[mtype*=normal][colornumber='12'],
+body .inline_nickname[colornumber='12'] {
+	color: #8E67E7;
 }
 
-body .sender[mtype*=normal][colornumber='13'], 
-body .inline_nickname[colornumber='13'] { 
-	color: #FFBB58; 
+body .sender[mtype*=normal][colornumber='13'],
+body .inline_nickname[colornumber='13'] {
+	color: #FFBB58;
 }
 
-body .sender[mtype*=normal][colornumber='14'], 
-body .inline_nickname[colornumber='14'] { 
-	color: #EDD7AD; 
+body .sender[mtype*=normal][colornumber='14'],
+body .inline_nickname[colornumber='14'] {
+	color: #EDD7AD;
 }
 
-body .sender[mtype*=normal][colornumber='15'], 
-body .inline_nickname[colornumber='15'] { 
+body .sender[mtype*=normal][colornumber='15'],
+body .inline_nickname[colornumber='15'] {
 	color: #FF1676;
 }
 
-body .sender[mtype*=normal][colornumber='16'], 
-body .inline_nickname[colornumber='16'] { 
+body .sender[mtype*=normal][colornumber='16'],
+body .inline_nickname[colornumber='16'] {
 	color: #706616;
 }
 
-body .sender[mtype*=normal][colornumber='17'], 
-body .inline_nickname[colornumber='17'] { 
+body .sender[mtype*=normal][colornumber='17'],
+body .inline_nickname[colornumber='17'] {
 	color: #46799c;
 }
 
-body .sender[mtype*=normal][colornumber='18'], 
-body .inline_nickname[colornumber='18'] { 
+body .sender[mtype*=normal][colornumber='18'],
+body .inline_nickname[colornumber='18'] {
 	color: #80372e;
 }
 
-body .sender[mtype*=normal][colornumber='19'], 
-body .inline_nickname[colornumber='19'] { 
+body .sender[mtype*=normal][colornumber='19'],
+body .inline_nickname[colornumber='19'] {
 	color: #8F478E;
 }
 
-body .sender[mtype*=normal][colornumber='20'], 
-body .inline_nickname[colornumber='20'] { 
+body .sender[mtype*=normal][colornumber='20'],
+body .inline_nickname[colornumber='20'] {
 	color: #5b9e4c;
 }
 
-body .sender[mtype*=normal][colornumber='21'], 
-body .inline_nickname[colornumber='21'] { 
+body .sender[mtype*=normal][colornumber='21'],
+body .inline_nickname[colornumber='21'] {
 	color: #13826c;
 }
 
-body .sender[mtype*=normal][colornumber='22'], 
-body .inline_nickname[colornumber='22'] { 
+body .sender[mtype*=normal][colornumber='22'],
+body .inline_nickname[colornumber='22'] {
 	color: #b13637;
 }
 
-body .sender[mtype*=normal][colornumber='23'], 
-body .inline_nickname[colornumber='23'] { 
+body .sender[mtype*=normal][colornumber='23'],
+body .inline_nickname[colornumber='23'] {
 	color: #e45d59;
 }
 
-body .sender[mtype*=normal][colornumber='24'], 
-body .inline_nickname[colornumber='24'] { 
+body .sender[mtype*=normal][colornumber='24'],
+body .inline_nickname[colornumber='24'] {
 	color: #1b51ae;
 }
 
-body .sender[mtype*=normal][colornumber='25'], 
-body .inline_nickname[colornumber='25'] { 
+body .sender[mtype*=normal][colornumber='25'],
+body .inline_nickname[colornumber='25'] {
 	color: #4855ac;
 }
 
-body .sender[mtype*=normal][colornumber='26'], 
-body .inline_nickname[colornumber='26'] { 
+body .sender[mtype*=normal][colornumber='26'],
+body .inline_nickname[colornumber='26'] {
 	color: #7f1d86;
 }
 
-body .sender[mtype*=normal][colornumber='27'], 
-body .inline_nickname[colornumber='27'] { 
+body .sender[mtype*=normal][colornumber='27'],
+body .inline_nickname[colornumber='27'] {
 	color: #73643f;
 }
 
-body .sender[mtype*=normal][colornumber='28'], 
-body .inline_nickname[colornumber='28'] { 
+body .sender[mtype*=normal][colornumber='28'],
+body .inline_nickname[colornumber='28'] {
 	color: #0b9578;
 }
 
-body .sender[mtype*=normal][colornumber='29'], 
-body .inline_nickname[colornumber='29'] { 
+body .sender[mtype*=normal][colornumber='29'],
+body .inline_nickname[colornumber='29'] {
 	color: #569c96;
 }
 
-body .sender[mtype*=normal][colornumber='30'], 
-body .inline_nickname[colornumber='30'] { 
+body .sender[mtype*=normal][colornumber='30'],
+body .inline_nickname[colornumber='30'] {
 	color: #08465f;
 }

--- a/Resources/Styles/Styles/Simplified Dark/design.css
+++ b/Resources/Styles/Styles/Simplified Dark/design.css
@@ -5,23 +5,28 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
-}	
+	overflow: hidden;
+}
 
 body {
 	color: #fff;
 	height: 100%;
  	z-index: 100;
 	font-size: 12px;
-	overflow: hidden;
-	overflow-y: visible;
 	background-color: #000;
 	font-family: "Lucida Grande";
 }
 
+body div#body_container {
+	height: 100%;
+}
+
 body div#body_home {
+	overflow-y: scroll;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	top: 0;
 	opacity: 0;
 	width: 100%;
 	z-index: 100;
@@ -47,7 +52,7 @@ body[dir=rtl] .sender {
 /* Loading Screen */
 
 body div#loading_screen {
-	position:absolute; 
+	position:absolute;
 	top: 50%;
 	left: 50%;
 	margin-top: -11px;
@@ -68,12 +73,12 @@ body div#loading_screen {
 
 body[dir=ltr] .time {
 	color: #666;
-	white-space: nowrap; 
+	white-space: nowrap;
 }
 
 body[dir=rtl] .time {
 	color: #666;
-	white-space: nowrap; 
+	white-space: nowrap;
 	padding-left: 0.4em;
 	display: inline-block;
 }
@@ -112,7 +117,7 @@ a:hover {
 	opacity: 0; /* Set by JavaScript */
 	z-index: 400;
 	color: #8E8E8E;
-	position: fixed;
+	position: absolute;
 	padding: 2px 0.5em 3px;
 	box-shadow: 0 1px 5px #777;
 	border-bottom: 1px solid #404040;
@@ -133,7 +138,7 @@ a:hover {
 	white-space: normal;
 }
 
-#topic_bar a, 
+#topic_bar a,
 #topic_bar span.channel {
 	color: #8E8E8E;
 	border-color: #8E8E8E;
@@ -194,7 +199,7 @@ div[id=mark] {
 
 /* Historic Line */
 
-.historic 
+.historic
 {
 	opacity: 0.6;
 }
@@ -343,7 +348,7 @@ body div.line[ltype*=dccfiletransfer] {
 
 /* Message of the Day (MOTD) */
 /* 720, 721, 722 are used by ShadowIRCd for Oper MOTD. */
-/* 372, 375, 376 are normal MOTD shared by several IRCds. */ 
+/* 372, 375, 376 are normal MOTD shared by several IRCds. */
 
 body div.line[command="372"],
 body div.line[command="721"] {
@@ -368,7 +373,7 @@ body div.line[command="722"] { /* End. */
 
 body div.line[command="372"] .message,
 body div.line[command="375"] .message,
-body div.line[command="376"] .message 
+body div.line[command="376"] .message
 body div.line[command="720"] .message,
 body div.line[command="721"] .message,
 body div.line[command="722"] .message {
@@ -436,161 +441,161 @@ body .inline_nickname {
 	font-weight: 700;
 }
 
-body div[ltype*=privmsg] .sender[mtype*=myself] { 
-	color: #B8DFFF; 
+body div[ltype*=privmsg] .sender[mtype*=myself] {
+	color: #B8DFFF;
 }
 
-body .sender[mtype*=normal][colornumber='0'], 
-body .inline_nickname[colornumber='0'] { 
-	color: red; 
+body .sender[mtype*=normal][colornumber='0'],
+body .inline_nickname[colornumber='0'] {
+	color: red;
 }
 
-body .sender[mtype*=normal][colornumber='1'], 
-body .inline_nickname[colornumber='1'] { 
-	color: #636aff; 
+body .sender[mtype*=normal][colornumber='1'],
+body .inline_nickname[colornumber='1'] {
+	color: #636aff;
 }
 
-body .sender[mtype*=normal][colornumber='2'], 
-body .inline_nickname[colornumber='2'] { 
-	color: #00BA00; 
+body .sender[mtype*=normal][colornumber='2'],
+body .inline_nickname[colornumber='2'] {
+	color: #00BA00;
 }
 
-body .sender[mtype*=normal][colornumber='3'], 
-body .inline_nickname[colornumber='3'] { 
-	color: #C083F2; 
+body .sender[mtype*=normal][colornumber='3'],
+body .inline_nickname[colornumber='3'] {
+	color: #C083F2;
 }
 
-body .sender[mtype*=normal][colornumber='4'], 
-body .inline_nickname[colornumber='4'] { 
-	color: #4DEDF0; 
+body .sender[mtype*=normal][colornumber='4'],
+body .inline_nickname[colornumber='4'] {
+	color: #4DEDF0;
 }
 
-body .sender[mtype*=normal][colornumber='5'], 
-body .inline_nickname[colornumber='5'] { 
-	color: #E422B2; 
+body .sender[mtype*=normal][colornumber='5'],
+body .inline_nickname[colornumber='5'] {
+	color: #E422B2;
 }
 
 body .sender[mtype*=normal][colornumber='6'],
-body .inline_nickname[colornumber='6'] { 
-	color: #EAE87E; 
+body .inline_nickname[colornumber='6'] {
+	color: #EAE87E;
 }
 
-body .sender[mtype*=normal][colornumber='7'], 
-body .inline_nickname[colornumber='7'] { 
-	color: #B8DFFF; 
+body .sender[mtype*=normal][colornumber='7'],
+body .inline_nickname[colornumber='7'] {
+	color: #B8DFFF;
 }
 
 body .sender[mtype*=normal][colornumber='8'],
-body .inline_nickname[colornumber='8'] { 
-	color: #75A1FB; 
+body .inline_nickname[colornumber='8'] {
+	color: #75A1FB;
 }
 
-body .sender[mtype*=normal][colornumber='9'], 
-body .inline_nickname[colornumber='9'] { 
-	color: #97C74B; 
+body .sender[mtype*=normal][colornumber='9'],
+body .inline_nickname[colornumber='9'] {
+	color: #97C74B;
 }
 
-body .sender[mtype*=normal][colornumber='10'], 
-body .inline_nickname[colornumber='10'] { 
-	color: #A5EAC4; 
+body .sender[mtype*=normal][colornumber='10'],
+body .inline_nickname[colornumber='10'] {
+	color: #A5EAC4;
 }
 
-body .sender[mtype*=normal][colornumber='11'], 
-body .inline_nickname[colornumber='11'] { 
-	color: #FFA6A0; 
+body .sender[mtype*=normal][colornumber='11'],
+body .inline_nickname[colornumber='11'] {
+	color: #FFA6A0;
 }
 
-body .sender[mtype*=normal][colornumber='12'], 
-body .inline_nickname[colornumber='12'] { 
-	color: #8E67E7; 
+body .sender[mtype*=normal][colornumber='12'],
+body .inline_nickname[colornumber='12'] {
+	color: #8E67E7;
 }
 
-body .sender[mtype*=normal][colornumber='13'], 
-body .inline_nickname[colornumber='13'] { 
-	color: #FFBB58; 
+body .sender[mtype*=normal][colornumber='13'],
+body .inline_nickname[colornumber='13'] {
+	color: #FFBB58;
 }
 
-body .sender[mtype*=normal][colornumber='14'], 
-body .inline_nickname[colornumber='14'] { 
-	color: #EDD7AD; 
+body .sender[mtype*=normal][colornumber='14'],
+body .inline_nickname[colornumber='14'] {
+	color: #EDD7AD;
 }
 
-body .sender[mtype*=normal][colornumber='15'], 
-body .inline_nickname[colornumber='15'] { 
+body .sender[mtype*=normal][colornumber='15'],
+body .inline_nickname[colornumber='15'] {
 	color: #FF1676;
 }
 
-body .sender[mtype*=normal][colornumber='16'], 
-body .inline_nickname[colornumber='16'] { 
+body .sender[mtype*=normal][colornumber='16'],
+body .inline_nickname[colornumber='16'] {
 	color: #706616;
 }
 
-body .sender[mtype*=normal][colornumber='17'], 
-body .inline_nickname[colornumber='17'] { 
+body .sender[mtype*=normal][colornumber='17'],
+body .inline_nickname[colornumber='17'] {
 	color: #46799c;
 }
 
-body .sender[mtype*=normal][colornumber='18'], 
-body .inline_nickname[colornumber='18'] { 
+body .sender[mtype*=normal][colornumber='18'],
+body .inline_nickname[colornumber='18'] {
 	color: #80372e;
 }
 
-body .sender[mtype*=normal][colornumber='19'], 
-body .inline_nickname[colornumber='19'] { 
+body .sender[mtype*=normal][colornumber='19'],
+body .inline_nickname[colornumber='19'] {
 	color: #8F478E;
 }
 
-body .sender[mtype*=normal][colornumber='20'], 
-body .inline_nickname[colornumber='20'] { 
+body .sender[mtype*=normal][colornumber='20'],
+body .inline_nickname[colornumber='20'] {
 	color: #5b9e4c;
 }
 
-body .sender[mtype*=normal][colornumber='21'], 
-body .inline_nickname[colornumber='21'] { 
+body .sender[mtype*=normal][colornumber='21'],
+body .inline_nickname[colornumber='21'] {
 	color: #13826c;
 }
 
-body .sender[mtype*=normal][colornumber='22'], 
-body .inline_nickname[colornumber='22'] { 
+body .sender[mtype*=normal][colornumber='22'],
+body .inline_nickname[colornumber='22'] {
 	color: #b13637;
 }
 
-body .sender[mtype*=normal][colornumber='23'], 
-body .inline_nickname[colornumber='23'] { 
+body .sender[mtype*=normal][colornumber='23'],
+body .inline_nickname[colornumber='23'] {
 	color: #e45d59;
 }
 
-body .sender[mtype*=normal][colornumber='24'], 
-body .inline_nickname[colornumber='24'] { 
+body .sender[mtype*=normal][colornumber='24'],
+body .inline_nickname[colornumber='24'] {
 	color: #1b51ae;
 }
 
-body .sender[mtype*=normal][colornumber='25'], 
-body .inline_nickname[colornumber='25'] { 
+body .sender[mtype*=normal][colornumber='25'],
+body .inline_nickname[colornumber='25'] {
 	color: #4855ac;
 }
 
-body .sender[mtype*=normal][colornumber='26'], 
-body .inline_nickname[colornumber='26'] { 
+body .sender[mtype*=normal][colornumber='26'],
+body .inline_nickname[colornumber='26'] {
 	color: #7f1d86;
 }
 
-body .sender[mtype*=normal][colornumber='27'], 
-body .inline_nickname[colornumber='27'] { 
+body .sender[mtype*=normal][colornumber='27'],
+body .inline_nickname[colornumber='27'] {
 	color: #73643f;
 }
 
-body .sender[mtype*=normal][colornumber='28'], 
-body .inline_nickname[colornumber='28'] { 
+body .sender[mtype*=normal][colornumber='28'],
+body .inline_nickname[colornumber='28'] {
 	color: #0b9578;
 }
 
-body .sender[mtype*=normal][colornumber='29'], 
-body .inline_nickname[colornumber='29'] { 
+body .sender[mtype*=normal][colornumber='29'],
+body .inline_nickname[colornumber='29'] {
 	color: #569c96;
 }
 
-body .sender[mtype*=normal][colornumber='30'], 
-body .inline_nickname[colornumber='30'] { 
+body .sender[mtype*=normal][colornumber='30'],
+body .inline_nickname[colornumber='30'] {
 	color: #08465f;
 }

--- a/Resources/Styles/Styles/Simplified Light/design.css
+++ b/Resources/Styles/Styles/Simplified Light/design.css
@@ -5,23 +5,29 @@
 	padding: 0;
 	font-size: 100%;
   	word-wrap: break-word;
-}	
+	overflow: hidden;
+}
 
 body {
 	color: #000;
 	height: 100%;
  	z-index: 100;
 	font-size: 12px;
-	overflow: hidden;
 	overflow-y: visible;
 	background-color: #fff;
 	font-family: "Lucida Grande";
 }
 
+body div#body_container {
+	height: 100%;
+}
+
 body div#body_home {
+	overflow-y: scroll;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	top: 0;
 	width: 100%;
 	z-index: 100;
 	max-height: 99.99%;
@@ -46,7 +52,7 @@ body[dir=rtl] .sender {
 /* Loading Screen */
 
 body div#loading_screen {
-	position:absolute; 
+	position:absolute;
 	top: 50%;
 	left: 50%;
 	margin-top: -11px;
@@ -67,12 +73,12 @@ body div#loading_screen {
 
 body[dir=ltr] .time {
 	color: #aaa;
-	white-space: nowrap; 
+	white-space: nowrap;
 }
 
 body[dir=rtl] .time {
 	color: #aaa;
-	white-space: nowrap; 
+	white-space: nowrap;
 	padding-left: 0.4em;
 	display: inline-block;
 }
@@ -111,7 +117,7 @@ a:hover {
 	z-index: 400;
 	opacity: 0; /* Set by JavaScript */
 	color: #FFFFFF;
-	position: fixed;
+	position: absolute;
 	padding: 2px 0.5em 3px;
 	box-shadow: 0 1px 5px #777;
 	border-bottom: 1px solid #61778F;
@@ -132,7 +138,7 @@ a:hover {
 	white-space: normal;
 }
 
-#topic_bar a, 
+#topic_bar a,
 #topic_bar span.channel {
 	color: #FFFFFF;
 	border-color: #FFFFFF;
@@ -193,7 +199,7 @@ div[id=mark] {
 
 /* Historic Line */
 
-.historic 
+.historic
 {
 	opacity: 0.6;
 }
@@ -342,7 +348,7 @@ body div.line[ltype*=dccfiletransfer] {
 
 /* Message of the Day (MOTD) */
 /* 720, 721, 722 are used by ShadowIRCd for Oper MOTD. */
-/* 372, 375, 376 are normal MOTD shared by several IRCds. */ 
+/* 372, 375, 376 are normal MOTD shared by several IRCds. */
 
 body div.line[command="372"],
 body div.line[command="721"] {
@@ -367,7 +373,7 @@ body div.line[command="722"] { /* End. */
 
 body div.line[command="372"] .message,
 body div.line[command="375"] .message,
-body div.line[command="376"] .message 
+body div.line[command="376"] .message
 body div.line[command="720"] .message,
 body div.line[command="721"] .message,
 body div.line[command="722"] .message {
@@ -435,161 +441,161 @@ body .inline_nickname {
 	font-weight: 700;
 }
 
-body div[ltype*=privmsg] .sender[mtype*=myself] { 
-	color: #ea0d68; 
+body div[ltype*=privmsg] .sender[mtype*=myself] {
+	color: #ea0d68;
 }
 
-body .sender[mtype*=normal][colornumber='0'], 
+body .sender[mtype*=normal][colornumber='0'],
 body .inline_nickname[colornumber='0'] {
-	color: #0080ff; 
+	color: #0080ff;
 }
 
-body .sender[mtype*=normal][colornumber='1'], 
+body .sender[mtype*=normal][colornumber='1'],
 body .inline_nickname[colornumber='1'] {
-	color: #059005; 
+	color: #059005;
 }
 
-body .sender[mtype*=normal][colornumber='2'], 
+body .sender[mtype*=normal][colornumber='2'],
 body .inline_nickname[colornumber='2'] {
-	color: #a80054; 
+	color: #a80054;
 }
 
-body .sender[mtype*=normal][colornumber='3'], 
+body .sender[mtype*=normal][colornumber='3'],
 body .inline_nickname[colornumber='3'] {
-	color: #9b0db1; 
+	color: #9b0db1;
 }
 
-body .sender[mtype*=normal][colornumber='4'], 
+body .sender[mtype*=normal][colornumber='4'],
 body .inline_nickname[colornumber='4'] {
-	color: #108860; 
+	color: #108860;
 }
 
-body .sender[mtype*=normal][colornumber='5'], 
+body .sender[mtype*=normal][colornumber='5'],
 body .inline_nickname[colornumber='5'] {
-	color: #7F4FFF; 
+	color: #7F4FFF;
 }
 
-body .sender[mtype*=normal][colornumber='6'], 
+body .sender[mtype*=normal][colornumber='6'],
 body .inline_nickname[colornumber='6'] {
-	color: #58701a; 
+	color: #58701a;
 }
 
-body .sender[mtype*=normal][colornumber='7'], 
+body .sender[mtype*=normal][colornumber='7'],
 body .inline_nickname[colornumber='7'] {
-	color: #620a8e; 
+	color: #620a8e;
 }
 
-body .sender[mtype*=normal][colornumber='8'], 
+body .sender[mtype*=normal][colornumber='8'],
 body .inline_nickname[colornumber='8'] {
-	color: #BB0008; 
+	color: #BB0008;
 }
 
-body .sender[mtype*=normal][colornumber='9'], 
+body .sender[mtype*=normal][colornumber='9'],
 body .inline_nickname[colornumber='9'] {
-	color: #44345f; 
+	color: #44345f;
 }
 
-body .sender[mtype*=normal][colornumber='10'], 
+body .sender[mtype*=normal][colornumber='10'],
 body .inline_nickname[colornumber='10'] {
-	color: #2f5353; 
+	color: #2f5353;
 }
 
-body .sender[mtype*=normal][colornumber='11'], 
+body .sender[mtype*=normal][colornumber='11'],
 body .inline_nickname[colornumber='11'] {
-	color: #904000; 
+	color: #904000;
 }
 
-body .sender[mtype*=normal][colornumber='12'], 
+body .sender[mtype*=normal][colornumber='12'],
 body .inline_nickname[colornumber='12'] {
-	color: #808000; 
+	color: #808000;
 }
 
-body .sender[mtype*=normal][colornumber='13'], 
+body .sender[mtype*=normal][colornumber='13'],
 body .inline_nickname[colornumber='13'] {
-	color: #57797e; 
+	color: #57797e;
 }
 
-body .sender[mtype*=normal][colornumber='14'], 
+body .sender[mtype*=normal][colornumber='14'],
 body .inline_nickname[colornumber='14'] {
-	color: #3333dd; 
+	color: #3333dd;
 }
 
-body .sender[mtype*=normal][colornumber='15'], 
+body .sender[mtype*=normal][colornumber='15'],
 body .inline_nickname[colornumber='15'] {
-	color: #5f4d22; 
+	color: #5f4d22;
 }
 
-body .sender[mtype*=normal][colornumber='16'], 
-body .inline_nickname[colornumber='16'] { 
+body .sender[mtype*=normal][colornumber='16'],
+body .inline_nickname[colornumber='16'] {
 	color: #706616;
 }
 
-body .sender[mtype*=normal][colornumber='17'], 
-body .inline_nickname[colornumber='17'] { 
+body .sender[mtype*=normal][colornumber='17'],
+body .inline_nickname[colornumber='17'] {
 	color: #46799c;
 }
 
-body .sender[mtype*=normal][colornumber='18'], 
-body .inline_nickname[colornumber='18'] { 
+body .sender[mtype*=normal][colornumber='18'],
+body .inline_nickname[colornumber='18'] {
 	color: #80372e;
 }
 
-body .sender[mtype*=normal][colornumber='19'], 
-body .inline_nickname[colornumber='19'] { 
+body .sender[mtype*=normal][colornumber='19'],
+body .inline_nickname[colornumber='19'] {
 	color: #8F478E;
 }
 
-body .sender[mtype*=normal][colornumber='20'], 
-body .inline_nickname[colornumber='20'] { 
+body .sender[mtype*=normal][colornumber='20'],
+body .inline_nickname[colornumber='20'] {
 	color: #5b9e4c;
 }
 
-body .sender[mtype*=normal][colornumber='21'], 
-body .inline_nickname[colornumber='21'] { 
+body .sender[mtype*=normal][colornumber='21'],
+body .inline_nickname[colornumber='21'] {
 	color: #13826c;
 }
 
-body .sender[mtype*=normal][colornumber='22'], 
-body .inline_nickname[colornumber='22'] { 
+body .sender[mtype*=normal][colornumber='22'],
+body .inline_nickname[colornumber='22'] {
 	color: #b13637;
 }
 
-body .sender[mtype*=normal][colornumber='23'], 
-body .inline_nickname[colornumber='23'] { 
+body .sender[mtype*=normal][colornumber='23'],
+body .inline_nickname[colornumber='23'] {
 	color: #e45d59;
 }
 
-body .sender[mtype*=normal][colornumber='24'], 
-body .inline_nickname[colornumber='24'] { 
+body .sender[mtype*=normal][colornumber='24'],
+body .inline_nickname[colornumber='24'] {
 	color: #1b51ae;
 }
 
-body .sender[mtype*=normal][colornumber='25'], 
-body .inline_nickname[colornumber='25'] { 
+body .sender[mtype*=normal][colornumber='25'],
+body .inline_nickname[colornumber='25'] {
 	color: #4855ac;
 }
 
-body .sender[mtype*=normal][colornumber='26'], 
-body .inline_nickname[colornumber='26'] { 
+body .sender[mtype*=normal][colornumber='26'],
+body .inline_nickname[colornumber='26'] {
 	color: #7f1d86;
 }
 
-body .sender[mtype*=normal][colornumber='27'], 
-body .inline_nickname[colornumber='27'] { 
+body .sender[mtype*=normal][colornumber='27'],
+body .inline_nickname[colornumber='27'] {
 	color: #73643f;
 }
 
-body .sender[mtype*=normal][colornumber='28'], 
-body .inline_nickname[colornumber='28'] { 
+body .sender[mtype*=normal][colornumber='28'],
+body .inline_nickname[colornumber='28'] {
 	color: #0b9578;
 }
 
-body .sender[mtype*=normal][colornumber='29'], 
-body .inline_nickname[colornumber='29'] { 
+body .sender[mtype*=normal][colornumber='29'],
+body .inline_nickname[colornumber='29'] {
 	color: #569c96;
 }
 
-body .sender[mtype*=normal][colornumber='30'], 
-body .inline_nickname[colornumber='30'] { 
+body .sender[mtype*=normal][colornumber='30'],
+body .inline_nickname[colornumber='30'] {
 	color: #08465f;
 }

--- a/Resources/Styles/Styles/Tomorrow Night (Eighties)/design.css
+++ b/Resources/Styles/Styles/Tomorrow Night (Eighties)/design.css
@@ -10,6 +10,7 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
+	overflow: hidden;
 }
 
 body {
@@ -17,16 +18,20 @@ body {
 	height: 100%;
 	z-index: 100;
 	font-size: 12px;
-	overflow: hidden;
-	overflow-y: visible;
 	background-color: #2D2D2D; /* Tomorrow Night Eighties: Background */
 	font-family: "EspressoMono-Regular", "Menlo";
 }
 
+body div#body_container {
+	height: 100%;
+}
+
 #body_home {
+	overflow-y: scroll;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	top: 0;
 	width: 100%;
 	z-index: 100;
 	max-height: 99.99%;
@@ -126,7 +131,7 @@ a:hover {
 	z-index: 400;
 	opacity: 0; /* Set by JavaScript */
 	color: #D1F1A9; /* Tomorrow Night Blue: Green */
-	position: fixed;
+	position: absolute;
 	padding: 2px 0.5em 3px;
 	background-color: rgba(113, 140, 00, 0.9); /* Tomorrow: Green 90% */
 	-webkit-transition: opacity 0.8s linear;

--- a/Resources/Styles/Styles/Tomorrow/design.css
+++ b/Resources/Styles/Styles/Tomorrow/design.css
@@ -10,6 +10,7 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
+	overflow: hidden;
 }
 
 body {
@@ -17,16 +18,20 @@ body {
 	height: 100%;
 	z-index: 100;
 	font-size: 12px;
-	overflow: hidden;
-	overflow-y: visible;
 	background-color: #FFFFFF; /* Tomorrow: Background */
 	font-family: "EspressoMono-Regular", "Menlo";
 }
 
+body div#body_container {
+	height: 100%;
+}
+
 #body_home {
+	overflow-y: scroll;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	top: 0;
 	width: 100%;
 	z-index: 100;
 	max-height: 99.99%;
@@ -131,7 +136,7 @@ a:hover {
 	z-index: 400;
 	opacity: 0; /* Set by JavaScript */
 	color: #718C00; /* Tomorrow Night Blue: Green */
-	position: fixed;
+	position: absolute;
 	padding: 2px 0.5em 3px;
 	background-color: rgba(209, 241, 169, 0.95); /* Tomorrow Night Blue: Green 95% */
 	-webkit-transition: opacity 0.8s linear;

--- a/Resources/Styles/Styles/Total Sublime/design.css
+++ b/Resources/Styles/Styles/Total Sublime/design.css
@@ -6,23 +6,28 @@
 	font-size: 100%;
 	word-wrap: break-word;
 	line-height: 1.7em;
-}	
+	overflow: hidden;
+}
 
 body {
 	color: #e7e7e7;
 	height: 100%;
  	z-index: 100;
 	font-size: 11px;
-	overflow: hidden;
-	overflow-y: visible;
 	background-color: #272822;
 	font-family: "Lucida Grande";
 }
 
+body div#body_container {
+	height: 100%;
+}
+
 body div#body_home {
+	overflow-y: scroll;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	top: 0;
 	opacity: 0;
 	width: 100%;
 	z-index: 100;
@@ -48,7 +53,7 @@ body[dir=rtl] .sender {
 /* Loading Screen */
 
 body div#loading_screen {
-	position:absolute; 
+	position:absolute;
 	top: 50%;
 	left: 50%;
 	margin-top: -11px;
@@ -77,7 +82,7 @@ body[dir=ltr] .time {
 
 body[dir=rtl] .time {
 	color: #999;
-	white-space: nowrap; 
+	white-space: nowrap;
 	padding-left: 0.4em;
 	display: inline-block;
 }
@@ -113,7 +118,7 @@ a:hover {
 	opacity: 0; /* Set by JavaScript */
 	z-index: 400;
 	color: #555;
-	position: fixed;
+	position: absolute;
 	padding: 2px 0.5em 3px;
 	box-shadow: 0 1px 5px #444;
 	border-bottom: 1px solid #222;
@@ -134,7 +139,7 @@ a:hover {
 	white-space: normal;
 }
 
-#topic_bar a, 
+#topic_bar a,
 #topic_bar span.channel {
 	color: #8E8E8E;
 	border-color: #8E8E8E;
@@ -225,15 +230,15 @@ body div.line.selectedUser[highlight=false] {
 
   	z-index: 190;
   	position: relative;
-  	
+
 	border-top: 0px !important;
-	border-bottom: 0px !important; 
+	border-bottom: 0px !important;
   	background-color: #34352d !important;
 }
 
 /* Historic Line */
 
-.historic 
+.historic
 {
 	opacity: 0.6;
 }
@@ -337,7 +342,7 @@ body div.line[ltype*=rawhtml] {
 
 /* Message of the Day (MOTD) */
 /* 720, 721, 722 are used by ShadowIRCd for Oper MOTD. */
-/* 372, 375, 376 are normal MOTD shared by several IRCds. */ 
+/* 372, 375, 376 are normal MOTD shared by several IRCds. */
 
 body div.line[command="372"],
 body div.line[command="721"] {
@@ -362,7 +367,7 @@ body div.line[command="722"] { /* End. */
 
 body div.line[command="372"] .message,
 body div.line[command="375"] .message,
-body div.line[command="376"] .message 
+body div.line[command="376"] .message
 body div.line[command="720"] .message,
 body div.line[command="721"] .message,
 body div.line[command="722"] .message {
@@ -430,161 +435,161 @@ body .inline_nickname {
 
 }
 
-body div[ltype*=privmsg] .sender[mtype*=myself] { 
-	color: #ff6f6f; 
+body div[ltype*=privmsg] .sender[mtype*=myself] {
+	color: #ff6f6f;
 }
 
-body .sender[mtype*=normal][colornumber='0'], 
-body .inline_nickname[colornumber='0'] { 
-	color: #ff91fe; 
+body .sender[mtype*=normal][colornumber='0'],
+body .inline_nickname[colornumber='0'] {
+	color: #ff91fe;
 }
 
-body .sender[mtype*=normal][colornumber='1'], 
-body .inline_nickname[colornumber='1'] { 
-	color: #ca91ff; 
+body .sender[mtype*=normal][colornumber='1'],
+body .inline_nickname[colornumber='1'] {
+	color: #ca91ff;
 }
 
-body .sender[mtype*=normal][colornumber='2'], 
-body .inline_nickname[colornumber='2'] { 
-	color: #9194ff; 
+body .sender[mtype*=normal][colornumber='2'],
+body .inline_nickname[colornumber='2'] {
+	color: #9194ff;
 }
 
-body .sender[mtype*=normal][colornumber='3'], 
-body .inline_nickname[colornumber='3'] { 
-	color: #91d2ff; 
+body .sender[mtype*=normal][colornumber='3'],
+body .inline_nickname[colornumber='3'] {
+	color: #91d2ff;
 }
 
-body .sender[mtype*=normal][colornumber='4'], 
-body .inline_nickname[colornumber='4'] { 
-	color: #91ffcf; 
+body .sender[mtype*=normal][colornumber='4'],
+body .inline_nickname[colornumber='4'] {
+	color: #91ffcf;
 }
 
-body .sender[mtype*=normal][colornumber='5'], 
-body .inline_nickname[colornumber='5'] { 
-	color: #91ff94; 
+body .sender[mtype*=normal][colornumber='5'],
+body .inline_nickname[colornumber='5'] {
+	color: #91ff94;
 }
 
 body .sender[mtype*=normal][colornumber='6'],
-body .inline_nickname[colornumber='6'] { 
-	color: #c0ff91; 
+body .inline_nickname[colornumber='6'] {
+	color: #c0ff91;
 }
 
-body .sender[mtype*=normal][colornumber='7'], 
-body .inline_nickname[colornumber='7'] { 
-	color: #f9ff91; 
+body .sender[mtype*=normal][colornumber='7'],
+body .inline_nickname[colornumber='7'] {
+	color: #f9ff91;
 }
 
 body .sender[mtype*=normal][colornumber='8'],
-body .inline_nickname[colornumber='8'] { 
-	color: #ffc291; 
+body .inline_nickname[colornumber='8'] {
+	color: #ffc291;
 }
 
-body .sender[mtype*=normal][colornumber='9'], 
-body .inline_nickname[colornumber='9'] { 
-	color: #ff4bac; 
+body .sender[mtype*=normal][colornumber='9'],
+body .inline_nickname[colornumber='9'] {
+	color: #ff4bac;
 }
 
-body .sender[mtype*=normal][colornumber='10'], 
-body .inline_nickname[colornumber='10'] { 
-	color: #e85bf9; 
+body .sender[mtype*=normal][colornumber='10'],
+body .inline_nickname[colornumber='10'] {
+	color: #e85bf9;
 }
 
-body .sender[mtype*=normal][colornumber='11'], 
-body .inline_nickname[colornumber='11'] { 
-	color: #9e69ff; 
+body .sender[mtype*=normal][colornumber='11'],
+body .inline_nickname[colornumber='11'] {
+	color: #9e69ff;
 }
 
-body .sender[mtype*=normal][colornumber='12'], 
-body .inline_nickname[colornumber='12'] { 
-	color: #7f99f9; 
+body .sender[mtype*=normal][colornumber='12'],
+body .inline_nickname[colornumber='12'] {
+	color: #7f99f9;
 }
 
-body .sender[mtype*=normal][colornumber='13'], 
-body .inline_nickname[colornumber='13'] { 
-	color: #4bc6ff; 
+body .sender[mtype*=normal][colornumber='13'],
+body .inline_nickname[colornumber='13'] {
+	color: #4bc6ff;
 }
 
-body .sender[mtype*=normal][colornumber='14'], 
-body .inline_nickname[colornumber='14'] { 
-	color: #4bffdb; 
+body .sender[mtype*=normal][colornumber='14'],
+body .inline_nickname[colornumber='14'] {
+	color: #4bffdb;
 }
 
-body .sender[mtype*=normal][colornumber='15'], 
-body .inline_nickname[colornumber='15'] { 
+body .sender[mtype*=normal][colornumber='15'],
+body .inline_nickname[colornumber='15'] {
 	color: #4bff93;
 }
 
-body .sender[mtype*=normal][colornumber='16'], 
-body .inline_nickname[colornumber='16'] { 
+body .sender[mtype*=normal][colornumber='16'],
+body .inline_nickname[colornumber='16'] {
 	color: #4bff4f;
 }
 
-body .sender[mtype*=normal][colornumber='17'], 
-body .inline_nickname[colornumber='17'] { 
+body .sender[mtype*=normal][colornumber='17'],
+body .inline_nickname[colornumber='17'] {
 	color: #97ff4b;
 }
 
-body .sender[mtype*=normal][colornumber='18'], 
-body .inline_nickname[colornumber='18'] { 
+body .sender[mtype*=normal][colornumber='18'],
+body .inline_nickname[colornumber='18'] {
 	color: #e3ff4b;
 }
 
-body .sender[mtype*=normal][colornumber='19'], 
-body .inline_nickname[colornumber='19'] { 
+body .sender[mtype*=normal][colornumber='19'],
+body .inline_nickname[colornumber='19'] {
 	color: #ffb94b;
 }
 
-body .sender[mtype*=normal][colornumber='20'], 
-body .inline_nickname[colornumber='20'] { 
+body .sender[mtype*=normal][colornumber='20'],
+body .inline_nickname[colornumber='20'] {
 	color: #ff824b;
 }
 
-body .sender[mtype*=normal][colornumber='21'], 
-body .inline_nickname[colornumber='21'] { 
+body .sender[mtype*=normal][colornumber='21'],
+body .inline_nickname[colornumber='21'] {
 	color: #d05e2c;
 }
 
-body .sender[mtype*=normal][colornumber='22'], 
-body .inline_nickname[colornumber='22'] { 
+body .sender[mtype*=normal][colornumber='22'],
+body .inline_nickname[colornumber='22'] {
 	color: #cab732;
 }
 
-body .sender[mtype*=normal][colornumber='23'], 
-body .inline_nickname[colornumber='23'] { 
+body .sender[mtype*=normal][colornumber='23'],
+body .inline_nickname[colornumber='23'] {
 	color: #97de10;
 }
 
-body .sender[mtype*=normal][colornumber='24'], 
-body .inline_nickname[colornumber='24'] { 
+body .sender[mtype*=normal][colornumber='24'],
+body .inline_nickname[colornumber='24'] {
 	color: #95c990;
 }
 
-body .sender[mtype*=normal][colornumber='25'], 
-body .inline_nickname[colornumber='25'] { 
+body .sender[mtype*=normal][colornumber='25'],
+body .inline_nickname[colornumber='25'] {
 	color: #04bb5f;
 }
 
-body .sender[mtype*=normal][colornumber='26'], 
-body .inline_nickname[colornumber='26'] { 
+body .sender[mtype*=normal][colornumber='26'],
+body .inline_nickname[colornumber='26'] {
 	color: #09c1cc;
 }
 
-body .sender[mtype*=normal][colornumber='27'], 
-body .inline_nickname[colornumber='27'] { 
+body .sender[mtype*=normal][colornumber='27'],
+body .inline_nickname[colornumber='27'] {
 	color: #5baeed;
 }
 
-body .sender[mtype*=normal][colornumber='28'], 
-body .inline_nickname[colornumber='28'] { 
+body .sender[mtype*=normal][colornumber='28'],
+body .inline_nickname[colornumber='28'] {
 	color: #9d4ef6;
 }
 
-body .sender[mtype*=normal][colornumber='29'], 
-body .inline_nickname[colornumber='29'] { 
+body .sender[mtype*=normal][colornumber='29'],
+body .inline_nickname[colornumber='29'] {
 	color: #ac69cb;
 }
 
-body .sender[mtype*=normal][colornumber='30'], 
-body .inline_nickname[colornumber='30'] { 
+body .sender[mtype*=normal][colornumber='30'],
+body .inline_nickname[colornumber='30'] {
 	color: #b902c9;
 }

--- a/Resources/Styles/Styles/nox/design.css
+++ b/Resources/Styles/Styles/nox/design.css
@@ -6,6 +6,7 @@
 	font-size: 100%;
 	-webkit-word-break: break-word;
 	word-wrap: break-word;
+	overflow: hidden;
 }
 
 body {
@@ -13,8 +14,6 @@ body {
 	height: 100%;
  	z-index: 100;
 	font-size: 12px;
-	overflow: hidden;
-	overflow-y: visible;
 	background-color: #1d1d1d;
 	font-family: "Helvetica Neue";
     font-weight: 200;
@@ -24,10 +23,16 @@ body {
 	clear: both;
   }
 
+body div#body_container {
+	height: 100%;
+}
+
 #body_home {
+	overflow-y: scroll;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	top: 0;
 	width: 100%;
 	z-index: 100;
 	max-height: 99.99%;
@@ -118,15 +123,16 @@ a:hover {
 /* Topic Bar */
 
 #topic_bar {
-	top: -50px;
+	top: 0;
 	left: 0;
 	right: 0;
+	top: 0;
 	padding-bottom: 5px;
 	opacity: 0; /* Set by JavaScript */
 	z-index: 400;
 	color: #dddddd;
-	position: fixed;
-	padding: 55px 0.5em 7px;
+	position: absolute;
+	padding: 7px 0.5em 7px;
 	box-shadow: 0 1px 5px #777;
 	border-bottom: 1px solid #404040;
 	-webkit-transition: opacity 0.8s linear;


### PR DESCRIPTION
By using position absolute and making the body fit the window and have the chat container scroll instead we can simulate the effect of the topic having positioned fixed.
