### PR TITLE
Fix issues with new way of displaying the topic

### DIFF
--- a/Resources/Javascript/API/corePrivate.js
+++ b/Resources/Javascript/API/corePrivate.js
@@ -83,7 +83,8 @@ Textual.fadeOutLoadingScreen = function(bodyOp, topicOp)
 /* Scrolling. */
 Textual.scrollToBottomOfView = function()
 {
-	document.body.scrollTop = document.body.scrollHeight;
+    var bhe = document.getElementById("body_home");
+	bhe.lastChild.scrollIntoView(false);
 	
 	Textual.viewPositionMovedToBottom();
 };

--- a/Resources/Styles/Styles/Astria/design.css
+++ b/Resources/Styles/Styles/Astria/design.css
@@ -5,7 +5,6 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
-	overflow: hidden;
 }
 
 body {
@@ -33,10 +32,6 @@ body div#body_home {
 	position: absolute;
 	opacity: 0; /* Set by JavaScript */
 	-webkit-transition: opacity 0.8s linear;
-}
-
-body[viewtype=channel] div#body_home {
-	max-height: 96.5%;
 }
 
 body .line {

--- a/Resources/Styles/Styles/Sapientia/design.css
+++ b/Resources/Styles/Styles/Sapientia/design.css
@@ -5,7 +5,6 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
-	overflow: hidden;
 }
 
 body {
@@ -33,10 +32,6 @@ body div#body_home {
 	position: absolute;
 	opacity: 0; /* Set by JavaScript */
 	-webkit-transition: opacity 0.8s linear;
-}
-
-body[viewtype=channel] div#body_home {
-	max-height: 96.5%;
 }
 
 body .line {

--- a/Resources/Styles/Styles/Simplified Dark/design.css
+++ b/Resources/Styles/Styles/Simplified Dark/design.css
@@ -5,7 +5,6 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
-	overflow: hidden;
 }
 
 body {
@@ -34,10 +33,6 @@ body div#body_home {
 	position: absolute;
 	opacity: 0; /* Set by JavaScript */
 	-webkit-transition: opacity 0.8s linear;
-}
-
-body[viewtype=channel] div#body_home {
-	max-height: 96.5%;
 }
 
 body .line {

--- a/Resources/Styles/Styles/Simplified Light/design.css
+++ b/Resources/Styles/Styles/Simplified Light/design.css
@@ -5,7 +5,6 @@
 	padding: 0;
 	font-size: 100%;
   	word-wrap: break-word;
-	overflow: hidden;
 }
 
 body {
@@ -34,10 +33,6 @@ body div#body_home {
 	position: absolute;
 	opacity: 0; /* Set by JavaScript */
 	-webkit-transition: opacity 0.8s linear;
-}
-
-body[viewtype=channel] div#body_home {
-	max-height: 96.5%;
 }
 
 body .line {

--- a/Resources/Styles/Styles/Tomorrow Night (Eighties)/design.css
+++ b/Resources/Styles/Styles/Tomorrow Night (Eighties)/design.css
@@ -10,7 +10,6 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
-	overflow: hidden;
 }
 
 body {
@@ -38,10 +37,6 @@ body div#body_container {
 	position: absolute;
 	opacity: 0; /* Set by JavaScript */
 	-webkit-transition: opacity 0.8s linear;
-}
-
-body[viewtype=channel] div#body_home {
-	max-height: 96.5%;
 }
 
 .line {

--- a/Resources/Styles/Styles/Tomorrow/design.css
+++ b/Resources/Styles/Styles/Tomorrow/design.css
@@ -10,7 +10,6 @@
 	padding: 0;
 	font-size: 100%;
 	word-wrap: break-word;
-	overflow: hidden;
 }
 
 body {
@@ -38,10 +37,6 @@ body div#body_container {
 	position: absolute;
 	opacity: 0; /* Set by JavaScript */
 	-webkit-transition: opacity 0.8s linear;
-}
-
-body[viewtype=channel] div#body_home {
-	max-height: 96.5%;
 }
 
 .line {

--- a/Resources/Styles/Styles/nox/scripts.js
+++ b/Resources/Styles/Styles/nox/scripts.js
@@ -99,7 +99,7 @@ Textual.newMessagePostedToView = function (line) {
                 }, 1000);
             }
         }
-
+    }
     updateNicknameAssociatedWithNewMessage(message);
 };
 


### PR DESCRIPTION
- Removed bottom indentation of body_home from themes based in the
  simplified family
- The overflow: hidden; is only required in Nox, in other themes it
  messes with the timestamp and has been removed.
- Use a different method for scrolling to the bottom of the chat, that
  works even if the scroll has to occur in an element instead of body.
