### PR TITLE
Fix timestamps in the "Total Sublime" style

### DIFF
--- a/Resources/Styles/Styles/Total Sublime/design.css
+++ b/Resources/Styles/Styles/Total Sublime/design.css
@@ -6,7 +6,6 @@
 	font-size: 100%;
 	word-wrap: break-word;
 	line-height: 1.7em;
-	overflow: hidden;
 }
 
 body {


### PR DESCRIPTION
An accidental addition to the theme causes Total Sublime’s timestamps
to collapse and hide. This fixes it.
