### PR TITLE
Preserve whitespace in git path.

### DIFF
--- a/Main Project (Textual).xcodeproj/UpdateVersionInfo.sh
+++ b/Main Project (Textual).xcodeproj/UpdateVersionInfo.sh
@@ -9,9 +9,9 @@ bundleVersion=$(/usr/libexec/PlistBuddy -c "Print \"CFBundleVersion\"" Info.plis
 bundleName=$(/usr/libexec/PlistBuddy -c "Print \"CFBundleName\"" Info.plist)
 
 gitBundle=`which git`
-gitDescribe=`${gitBundle} describe --long`
+gitDescribe=`"${gitBundle}" describe --long`
 gitRefInfo=$(echo $gitDescribe | grep -oE "([0-9]{1,3})\-([a-zA-Z0-9]{8})")
-gitCommitCount=`${gitBundle} rev-list HEAD --count`
+gitCommitCount=`"${gitBundle}" rev-list HEAD --count`
 
 buildRef="${bundleVersionShort}-${gitRefInfo}-${TEXTUAL_GITREF_BUILD_ID}"
 


### PR DESCRIPTION
This fixes an error if Xcode is installed on a partition with a space in
it, because "which git" returns Xcode's bundled git.
