### PR TITLE
Uncheck highlightNickname button when regular expressions are selected for highlights

### DIFF
--- a/Classes/Dialogs/Preferences/TDCPreferencesController.m
+++ b/Classes/Dialogs/Preferences/TDCPreferencesController.m
@@ -873,6 +873,7 @@
 {
     if ([TPCPreferences highlightMatchingMethod] == TXNicknameHighlightRegularExpressionMatchType) {
         [[self highlightNicknameButton] setEnabled:NO];
+        [[self highlightNicknameButton] setState: NSOffState];
     } else {
         [[self highlightNicknameButton] setEnabled:YES];
     }


### PR DESCRIPTION
Simply disabling the highlight current nickname control while the checkbox is still checked may lead users to believe it is being forced ON, not OFF. This corrects this behaviour
