### PR TITLE
Hide "highlight current nick" instead of disable

### DIFF
--- a/Classes/Dialogs/Preferences/TDCPreferencesController.m
+++ b/Classes/Dialogs/Preferences/TDCPreferencesController.m
@@ -872,9 +872,9 @@
 - (void)onChangedHighlightType:(id)sender
 {
     if ([TPCPreferences highlightMatchingMethod] == TXNicknameHighlightRegularExpressionMatchType) {
-        [[self highlightNicknameButton] setEnabled:NO];
+        [[self highlightNicknameButton] setHidden:YES];
     } else {
-        [[self highlightNicknameButton] setEnabled:YES];
+        [[self highlightNicknameButton] setHidden:NO];
     }
 	
 	[[self addExcludeKeywordButton] setEnabled:YES];


### PR DESCRIPTION
The checkbox being disabled while still checked may confuse the user to
think it is being forced ON, hiding the checkbox is a better way to
indicate that the option is rather no longer available.
