### PR TITLE
Use /bin/date explicitly in UpdateVersionInfo

### DIFF
--- a/Main Project (Textual).xcodeproj/UpdateVersionInfo.sh
+++ b/Main Project (Textual).xcodeproj/UpdateVersionInfo.sh
@@ -9,7 +9,7 @@ bundleVersionForComparisons=$(/usr/libexec/PlistBuddy -c "Print \"TXBundleVersio
 bundleVersionShort=$(/usr/libexec/PlistBuddy -c "Print \"CFBundleShortVersionString\"" Info.plist)
 bundleName=$(/usr/libexec/PlistBuddy -c "Print \"CFBundleName\"" Info.plist)
 
-bundleVersion=`date -r "${gitDateOfLastCommit}" "+%y%m%d.%H"`
+bundleVersion=`/bin/date -r "${gitDateOfLastCommit}" "+%y%m%d.%H"`
 
 
 /usr/libexec/PlistBuddy -c "Set \"CFBundleVersion\" \"${bundleVersion}\"" Info.plist


### PR DESCRIPTION
Homebrew installed `date` (provided by `coreutils`) uses different command line arguments. This commit explicitly uses the host date binary instead of the first one on the `$PATH`.
