### PR TITLE
Save the last message server time if we're showing the old scrollback ra...

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -474,7 +474,7 @@
 	self.isTerminating = YES;
 
 	if ([self isCapacityEnabled:ClientIRCv3SupportedCapacityServerTime]) {
-		if ([TPCPreferences logToDiskIsEnabled]) {
+		if ([TPCPreferences reloadScrollbackOnLaunch]) {
 			if (self.lastMessageServerTime > 0) {
 				self.config.cachedLastServerTimeCapacityReceivedAtTimestamp = self.lastMessageServerTime;
 			}
@@ -631,7 +631,7 @@
 
 - (NSTimeInterval)lastMessageServerTimeWithCachedValue
 {
-	if ([TPCPreferences logToDiskIsEnabled]) {
+	if ([TPCPreferences reloadScrollbackOnLaunch]) {
 		if (fabs(self.lastMessageServerTime) == 0) {
 			double storedTime = self.config.cachedLastServerTimeCapacityReceivedAtTimestamp;
 


### PR DESCRIPTION
...ther than saving it if we're saving logs to disk