### PR TITLE
Fixed Action posts being truncated incorrectly.

### DIFF
--- a/Classes/Headers/IRC.h
+++ b/Classes/Headers/IRC.h
@@ -38,7 +38,7 @@
 #import "TextualApplication.h"
 
 /* Hard limits. */
-#define TXMaximumIRCBodyLength						512
+#define TXMaximumIRCBodyLength						510
 #define TXMaximumIRCNicknameLength					50
 #define TXMaximumIRCUsernameLength					40
 

--- a/Classes/Library/Color Formatting/IRCColorFormat.m
+++ b/Classes/Library/Color Formatting/IRCColorFormat.m
@@ -142,7 +142,7 @@
 
 #define	_textTruncationPRIVMSGCommandConstant				14
 #define _textTruncationNOTICECommandConstant				14
-#define	_textTruncationACTIONCommandConstant				8
+#define	_textTruncationACTIONCommandConstant				30
 
 #define _textTruncationHostmaskConstant						15 // Used if local user host is unknown
 


### PR DESCRIPTION
* Updated IRC Max body length in accordance with RFC 2813 Section 3.3 "Thus, there are 510 characters maximum allowed for the command and its parameters."
* Updated Action command constant for text truncation to include the length of the PrivMsg character and Action command characters