### PR TITLE
Don't sum channels with unread count hidden

### DIFF
--- a/Classes/Views/TVCDockIcon.m
+++ b/Classes/Views/TVCDockIcon.m
@@ -53,7 +53,7 @@ static NSInteger _cachedHighlightCount = -1;
 	
 	for (IRCClient *u in [worldController() clientList]) {
 		for (IRCChannel *c in [u channelList]) {
-			if (c.config.pushNotifications) {
+			if (c.config.pushNotifications && c.config.showTreeBadgeCount) {
 				messageCount += c.dockUnreadCount;
 			}
 			


### PR DESCRIPTION
Channels with unread message counts turned off are summed into the unread message badge on the dock icon - IMO this is undesired behavior.
