### PR TITLE
Add preference to bounce the Dock icon repeatedly

### DIFF
--- a/Classes/Dialogs/Preferences/TDCPreferencesController.m
+++ b/Classes/Dialogs/Preferences/TDCPreferencesController.m
@@ -80,6 +80,7 @@
 @property (nonatomic, strong) IBOutlet NSArrayController *matchKeywordsArrayController;
 @property (nonatomic, strong) IBOutlet NSButton *addExcludeKeywordButton;
 @property (nonatomic, strong) IBOutlet NSButton *alertBounceDockIconButton;
+@property (nonatomic, strong) IBOutlet NSButton *alertBounceDockIconRepeatedlyButton;
 @property (nonatomic, strong) IBOutlet NSButton *alertDisableWhileAwayButton;
 @property (nonatomic, strong) IBOutlet NSButton *alertPushNotificationButton;
 @property (nonatomic, strong) IBOutlet NSButton *alertSpeakEventButton;
@@ -135,6 +136,7 @@
 - (IBAction)onChangedAlertSound:(id)sender;
 - (IBAction)onChangedAlertDisableWhileAway:(id)sender;
 - (IBAction)onChangedAlertBounceDockIcon:(id)sender;
+- (IBAction)onChangedAlertBounceDockIconRepeatedly:(id)sender;
 - (IBAction)onChangedAlertNotification:(id)sender;
 - (IBAction)onChangedAlertType:(id)sender;
 
@@ -608,6 +610,8 @@
     [[self alertPushNotificationButton] setState:[alert pushNotification]];
     [[self alertDisableWhileAwayButton] setState:[alert disabledWhileAway]];
     [[self alertBounceDockIconButton] setState:[alert bounceDockIcon]];
+    [[self alertBounceDockIconRepeatedlyButton] setState:[alert bounceDockIconRepeatedly]];
+    [[self alertBounceDockIconRepeatedlyButton] setEnabled: ([[self alertBounceDockIconButton] state] == NSOnState)];
 
 	NSInteger soundObject = [[self availableSounds] indexOfObject:[alert alertSound]];
 	
@@ -658,6 +662,19 @@
     TDCPreferencesSoundWrapper *alert = [TDCPreferencesSoundWrapper soundWrapperWithEventType:alertType];
     
 	[alert setBounceDockIcon:[[self alertBounceDockIconButton] state]];
+	
+	alert = nil;
+    
+	[[self alertBounceDockIconRepeatedlyButton] setEnabled: ([[self alertBounceDockIconButton] state] == NSOnState)];
+}
+
+- (void)onChangedAlertBounceDockIconRepeatedly:(id)sender
+{
+	TXNotificationType alertType = (TXNotificationType)[[self alertTypeChoiceButton] selectedTag];
+    
+	TDCPreferencesSoundWrapper *alert = [TDCPreferencesSoundWrapper soundWrapperWithEventType:alertType];
+    
+	[alert setBounceDockIconRepeatedly:[[self alertBounceDockIconRepeatedlyButton] state]];
 	
 	alert = nil;
 }

--- a/Classes/Dialogs/Preferences/TDCPreferencesSoundWrapper.m
+++ b/Classes/Dialogs/Preferences/TDCPreferencesSoundWrapper.m
@@ -132,4 +132,14 @@ NSString * const TXEmptySoundAlertPreferenceValue = @"None";
     [TPCPreferences setBounceDockIcon:value forEvent:self.eventType];
 }
 
+- (BOOL)bounceDockIconRepeatedly
+{
+    return [TPCPreferences bounceDockIconRepeatedlyForEvent:self.eventType];
+}
+
+- (void)setBounceDockIconRepeatedly:(BOOL)value
+{
+    [TPCPreferences setBounceDockIconRepeatedly:value forEvent:self.eventType];
+}
+
 @end

--- a/Classes/Headers/TDCPreferencesSoundWrapper.h
+++ b/Classes/Headers/TDCPreferencesSoundWrapper.h
@@ -48,6 +48,7 @@ TEXTUAL_EXTERN NSString * const TXEmptySoundAlertPreferenceValue;
 @property (nonatomic, assign) BOOL pushNotification;
 @property (nonatomic, assign) BOOL disabledWhileAway;
 @property (nonatomic, assign) BOOL bounceDockIcon;
+@property (nonatomic, assign) BOOL bounceDockIconRepeatedly;
 
 + (NSString *)localizedEmptySoundSelectionLabel;
 

--- a/Classes/Headers/TPCPreferences.h
+++ b/Classes/Headers/TPCPreferences.h
@@ -245,12 +245,14 @@ typedef NS_ENUM(NSUInteger, TXFileTransferIPAddressDetectionMethod) {
 + (BOOL)growlEnabledForEvent:(TXNotificationType)event;
 + (BOOL)disabledWhileAwayForEvent:(TXNotificationType)event;
 + (BOOL)bounceDockIconForEvent:(TXNotificationType)event;
++ (BOOL)bounceDockIconRepeatedlyForEvent:(TXNotificationType)event;
 
 + (void)setSound:(NSString *)value forEvent:(TXNotificationType)event;
 
 + (void)setGrowlEnabled:(BOOL)value forEvent:(TXNotificationType)event;
 + (void)setDisabledWhileAway:(BOOL)value forEvent:(TXNotificationType)event;
 + (void)setBounceDockIcon:(BOOL)value forEvent:(TXNotificationType)event;
++ (void)setBounceDockIconRepeatedly:(BOOL)value forEvent:(TXNotificationType)event;
 + (void)setEventIsSpoken:(BOOL)value forEvent:(TXNotificationType)event;
 
 + (TXTabKeyAction)tabKeyAction;

--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -1278,9 +1278,13 @@ NSString * const IRCClientChannelListWasModifiedNotification = @"IRCClientChanne
 		return YES;
 	}
     
-    if ([TPCPreferences bounceDockIconForEvent:type]) {
-        [NSApp requestUserAttention:NSInformationalRequest];
-    }
+	if ([TPCPreferences bounceDockIconForEvent:type]) {
+		if ([TPCPreferences bounceDockIconRepeatedlyForEvent:type]) {
+			[NSApp requestUserAttention:NSCriticalRequest];
+		} else {
+			[NSApp requestUserAttention:NSInformationalRequest];
+		}
+	}
 
 	if ([sharedGrowlController() areNotificationsDisabled]) {
 		return YES;
@@ -1361,9 +1365,13 @@ NSString * const IRCClientChannelListWasModifiedNotification = @"IRCClientChanne
 	//NSObjectIsEmptyAssertReturn(text, NO);
 	//NSObjectIsEmptyAssertReturn(nick, NO);
     
-    if ([TPCPreferences bounceDockIconForEvent:type]) {
-        [NSApp requestUserAttention:NSInformationalRequest];
-    }
+	if ([TPCPreferences bounceDockIconForEvent:type]) {
+		if ([TPCPreferences bounceDockIconRepeatedlyForEvent:type]) {
+			[NSApp requestUserAttention:NSCriticalRequest];
+		} else {
+			[NSApp requestUserAttention:NSInformationalRequest];
+		}
+	}
 	
 	if ([sharedGrowlController() areNotificationsDisabled]) {
 		return YES;

--- a/Classes/Preferences/TPCPreferences.m
+++ b/Classes/Preferences/TPCPreferences.m
@@ -731,6 +731,28 @@ NSInteger const TPCPreferencesDictionaryVersion		= 100;
 	[RZUserDefaults() setBool:value forKey:key];
 }
 
++ (BOOL)bounceDockIconRepeatedlyForEvent:(TXNotificationType)event
+{
+	NSString *okey = [TPCPreferences keyForEvent:event];
+
+	NSObjectIsEmptyAssertReturn(okey, NO);
+
+	NSString *key = [okey stringByAppendingString:@" -> Bounce Dock Icon Repeatedly"];
+
+	return [RZUserDefaults() boolForKey:key];
+}
+
++ (void)setBounceDockIconRepeatedly:(BOOL)value forEvent:(TXNotificationType)event
+{
+	NSString *okey = [TPCPreferences keyForEvent:event];
+
+	NSObjectIsEmptyAssert(okey);
+
+	NSString *key = [okey stringByAppendingString:@" -> Bounce Dock Icon Repeatedly"];
+
+	[RZUserDefaults() setBool:value forKey:key];
+}
+
 + (BOOL)speakEvent:(TXNotificationType)event
 {
 	NSString *okey = [TPCPreferences keyForEvent:event];

--- a/Resources/User Interface/English.lproj/TDCPreferences.xib
+++ b/Resources/User Interface/English.lproj/TDCPreferences.xib
@@ -10,6 +10,7 @@
             <connections>
                 <outlet property="addExcludeKeywordButton" destination="KgU-fm-1CL" id="Yh1-uA-Lzy"/>
                 <outlet property="alertBounceDockIconButton" destination="lHl-sy-SBb" id="dNa-Ig-gbA"/>
+                <outlet property="alertBounceDockIconRepeatedlyButton" destination="Izn-3U-WFY" id="t0Y-y0-uqa"/>
                 <outlet property="alertDisableWhileAwayButton" destination="pyR-Yq-9tk" id="YHI-cT-iku"/>
                 <outlet property="alertNotificationDestinationTextField" destination="O82-On-A00" id="K1U-BT-rCB"/>
                 <outlet property="alertPushNotificationButton" destination="fyC-tf-kOI" id="Yru-lz-bqp"/>
@@ -1083,17 +1084,6 @@ DQ
                         <action selector="onChangedAlertSpoken:" target="-2" id="iph-MR-aty"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="lHl-sy-SBb">
-                    <rect key="frame" x="117" y="197" width="123" height="18"/>
-                    <animations/>
-                    <buttonCell key="cell" type="check" title="Bounce dock icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="QLU-i1-tIY">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="titleBar" size="12"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="onChangedAlertBounceDockIcon:" target="-2" id="ftP-RY-zHs"/>
-                    </connections>
-                </button>
                 <box appearanceType="aqua" verticalHuggingPriority="750" alphaValue="0.5" title="Box" boxType="separator" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="nkc-Mt-osY">
                     <rect key="frame" x="434" y="342" width="106" height="5"/>
                     <animations/>
@@ -1226,6 +1216,28 @@ DQ
                     </buttonCell>
                     <connections>
                         <action selector="onChangedAlertNotification:" target="-2" id="c1S-wp-lbA"/>
+                    </connections>
+                </button>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Izn-3U-WFY">
+                    <rect key="frame" x="247" y="199" width="90" height="18"/>
+                    <animations/>
+                    <buttonCell key="cell" type="check" title="Repeatedly" bezelStyle="regularSquare" imagePosition="left" inset="2" id="bko-ZV-lwT">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="onChangedAlertBounceDockIconRepeatedly:" target="-2" id="Q4k-4M-Bgz"/>
+                    </connections>
+                </button>
+                <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lHl-sy-SBb">
+                    <rect key="frame" x="117" y="198" width="123" height="18"/>
+                    <animations/>
+                    <buttonCell key="cell" type="check" title="Bounce dock icon" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="QLU-i1-tIY">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="titleBar" size="12"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="onChangedAlertBounceDockIcon:" target="-2" id="ftP-RY-zHs"/>
                     </connections>
                 </button>
             </subviews>


### PR DESCRIPTION
Add a notification preference to allow the user to choose to bounce the dock icon repeatedly rather than just once. This is useful for those of us that have a our dock's hidden and so don't see the badge.