### PR TITLE
Bug (missing right bracket)

### DIFF
--- a/Classes/Library/TLOLicenseManagerDownloader.m
+++ b/Classes/Library/TLOLicenseManagerDownloader.m
@@ -355,7 +355,7 @@ static BOOL TLOLicenseManagerDownloaderConnectionSelected = NO;
 				(void)[TLOPopupPrompts dialogWindowWithMessage:TXTLS(@"TLOLicenseManager[1003][2]")
 														 title:TXTLS(@"TLOLicenseManager[1003][1]")
 												 defaultButton:TXTLS(@"BasicLanguage[1011]")
-											   alternateButton:nil;
+											   alternateButton:nil];
 
 				_performCompletionBlockAndReturn(NO)
 			}


### PR DESCRIPTION
Build fails unless right closing bracket is added. 

/Textual/Classes/Library/TLOLicenseManagerDownloader.m