### PR TITLE
Fix for ARC compiler error

### DIFF
--- a/Classes/IRC/IRCNetworkList.m
+++ b/Classes/IRC/IRCNetworkList.m
@@ -38,7 +38,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface IRCNetworkList ()
-@property (nonatomic, copy, readwrite) NSArray<IRCNetwork *> *listOfNetworks;
+@property (nonatomic, strong, readwrite) NSArray<IRCNetwork *> *listOfNetworks;
 @end
 
 @interface IRCNetwork ()


### PR DESCRIPTION
Previous warning was "ARC forbids synthesizing a property with
unspecified ownership or storage