### PR TITLE
When trying to join an already joined channel, jump to it

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -3668,9 +3668,16 @@ DESIGNATED_INITIALIZER_EXCEPTION_BODY_END
 				}
 			}
 
-			[self enableInUserInvokedCommandProperty:&self->_inUserInvokedJoinRequest];
-
-			[self send:IRCPrivateCommandIndex("join"), targetChannelName, stringIn.string, nil];
+			IRCTreeItem* targetChannel = [self findChannel: targetChannelName];
+			if(targetChannel.isActive)
+			{
+				[mainWindow() select:targetChannel];
+			}
+			else
+			{
+				[self enableInUserInvokedCommandProperty:&self->_inUserInvokedJoinRequest];
+				[self send:IRCPrivateCommandIndex("join"), targetChannelName, stringIn.string, nil];
+			}
 
 			break;
 		}


### PR DESCRIPTION
If a user tries to join an already joined channel, Textual will now jump to it instead of doing nothing.