### PR TITLE
Simplify max nicklen checks for hostmask parsing

### DIFF
--- a/Sources/App/Classes/Helpers/Cocoa (Objective-C)/NSStringHelper.m
+++ b/Sources/App/Classes/Helpers/Cocoa (Objective-C)/NSStringHelper.m
@@ -171,34 +171,6 @@ NSStringEncoding const TXDefaultFallbackStringEncoding = NSISOLatin1StringEncodi
 {
 	NSUInteger maximumLength = TXMaximumIRCNicknameLength;
 
-	if (client) {
-		/* At least one server has been found (gitter.im) has been found
-		 which does not send a configuration profile. They allow a 
-		 nickname length larger than IRCISupportInfo uses as a default
-		 which means parsing will go wonky. */
-		/* A smarter workaround would probably to check if specific 
-		 configuration options were received (e.g. "NICKLEN"), but that 
-		 has more overhead than using a boolean. */
-
-		if (client.supportInfo.configurationReceived) {
-			maximumLength = client.supportInfo.maximumNicknameLength;
-		} else {
-			maximumLength = 0;
-		}
-
-		/* If we are connected to ZNC, then do not enforce maximum 
-		 nickname length. It is easier to disable this check than
-		 to check whether a nickname (e.g. *buffextras) should be
-		 handled differently. */
-		if (client.isConnectedToZNC) {
-			maximumLength = 0;
-		}
-	}
-
-	if (maximumLength == 0) {
-		maximumLength = TXMaximumIRCNicknameLength;
-	}
-
 	return ([self isNotEqualTo:@"*"] &&
 			self.length > 0 &&
 			self.length <= maximumLength &&


### PR DESCRIPTION
This removes checking isupport NICKLEN for `isHostmaskNicknameOn` (used for sender/prefix parsing) in all cases.

Reasons:
* This was explicitly disabled in several cases anyway (missing isupport entirely, znc)
* This would fallback to a default of 9 when no NICKLEN was provided in isupport, but a default of 50 when explicitly disabled
* NICKLEN is not strictly the maximum length of a nickname on an IRC server. See:
** https://tools.ietf.org/html/draft-hardy-irc-isupport-00#section-4.14 "A client elsewhere on the network MAY use a nick length of higher value"
** https://tools.ietf.org/html/draft-brocklesby-irc-isupport-03#section-3.13 "   This parameter does not restrict the length of any nicknames other clients on the network may use"
** https://defs.ircdocs.horse/defs/isupport.html#nicklen "Other clients on the network may have nicknames longer than this."

The most serious issue here is for servers *with* ISUPPORT but no NICKLEN key, with nicks longer than 9 chars, where parsing just silently breaks and stuff like server-initiated JOINs fail to register.

This now always uses a limit of 50, which is arbitrary but probably a safe enough sanity check.