### PR TITLE
Add hackint to list of IRC networks

### DIFF
--- a/Sources/App/Resources/Property Lists/IRCNetworks.plist
+++ b/Sources/App/Resources/Property Lists/IRCNetworks.plist
@@ -299,5 +299,14 @@
 		<key>prefersSecuredConnection</key>
 		<true/>
 	</dict>
+	<key>hackint</key>
+	<dict>
+		<key>serverAddress</key>
+		<string>irc.hackint.org</string>
+		<key>serverPort</key>
+		<integer>6697</integer>
+		<key>prefersSecuredConnection</key>
+		<true/>
+	</dict>	
 </dict>
 </plist>


### PR DESCRIPTION
Hey, I would like to add hackint to the list of built-in IRC networks. I hope this is the right way to do it.

I ordered us below freenode, as our name is written in lower case as well.