### PR TITLE
[Script Support] Check for script executability instead of comparing extensions

### DIFF
--- a/Sources/App/Classes/Helpers/Plugin Architecture/THOPluginManager.m
+++ b/Sources/App/Classes/Helpers/Plugin Architecture/THOPluginManager.m
@@ -240,15 +240,17 @@ NSString * const THOPluginManagerFinishedLoadingPluginsNotification = @"THOPlugi
 		NSArray *pathFiles = [RZFileManager() contentsOfDirectoryAtPath:path error:NULL];
 
 		for (NSString *file in pathFiles) {
+			NSString *filePath = [path stringByAppendingPathComponent:file];
+
 			NSString *fileExtension = file.pathExtension;
 
 			NSString *fileWithoutExtension = file.stringByDeletingPathExtension;
 
 			NSString *command = fileWithoutExtension.lowercaseString;
 
-			BOOL executable = [RZFileManager() isExecutableFileAtPath:file];
+			BOOL executable = [RZFileManager() isExecutableFileAtPath:filePath];
 
-			if (executable == NO && fileExtension != TPCResourceManagerScriptDocumentTypeExtensionWithoutPeriod) {
+			if (executable == NO && ![fileExtension isEqualToString:TPCResourceManagerScriptDocumentTypeExtensionWithoutPeriod]) {
 				LogToConsoleDebug("WARNING: File “%@“ found in unsupervised script folder but it does not have a file extension recognized by Textual. It will be ignored.", file);
 
 				continue;
@@ -259,8 +261,6 @@ NSString * const THOPluginManagerFinishedLoadingPluginsNotification = @"THOPlugi
 			}
 
 			if (returnPathInfo) {
-				NSString *filePath = [path stringByAppendingPathComponent:file];
-
 				[returnValue setObjectWithoutOverride:filePath forKey:command];
 			} else {
 				[returnValue addObjectWithoutDuplication:command];

--- a/Sources/App/Classes/Helpers/Plugin Architecture/THOPluginManager.m
+++ b/Sources/App/Classes/Helpers/Plugin Architecture/THOPluginManager.m
@@ -222,8 +222,6 @@ NSString * const THOPluginManagerFinishedLoadingPluginsNotification = @"THOPlugi
 {
 	NSArray *forbiddenCommands = self.listOfForbiddenCommandNames;
 
-	NSArray *scriptExtensions = @[@"scpt", @"py", @"pyc", @"rb", @"pl", @"sh", @"php", @"bash"];
-
 	NSArray *scriptPaths =
 	[RZFileManager() buildPathArray:
 		[TPCPathInfo customScripts],
@@ -248,7 +246,9 @@ NSString * const THOPluginManagerFinishedLoadingPluginsNotification = @"THOPlugi
 
 			NSString *command = fileWithoutExtension.lowercaseString;
 
-			if ([scriptExtensions containsObject:fileExtension] == NO) {
+            BOOL executable = [RZFileManager() isExecutableFileAtPath:file];
+
+			if (executable == NO && fileExtension != TPCResourceManagerScriptDocumentTypeExtensionWithoutPeriod) {
 				LogToConsoleDebug("WARNING: File “%@“ found in unsupervised script folder but it does not have a file extension recognized by Textual. It will be ignored.", file);
 
 				continue;

--- a/Sources/App/Classes/Helpers/Plugin Architecture/THOPluginManager.m
+++ b/Sources/App/Classes/Helpers/Plugin Architecture/THOPluginManager.m
@@ -246,7 +246,7 @@ NSString * const THOPluginManagerFinishedLoadingPluginsNotification = @"THOPlugi
 
 			NSString *command = fileWithoutExtension.lowercaseString;
 
-            BOOL executable = [RZFileManager() isExecutableFileAtPath:file];
+			BOOL executable = [RZFileManager() isExecutableFileAtPath:file];
 
 			if (executable == NO && fileExtension != TPCResourceManagerScriptDocumentTypeExtensionWithoutPeriod) {
 				LogToConsoleDebug("WARNING: File “%@“ found in unsupervised script folder but it does not have a file extension recognized by Textual. It will be ignored.", file);


### PR DESCRIPTION
Currently only several scripting languages are "_supported_" (files with unrecognised extensions are filtered out), but there are no reasons to prevent loading scripts written in other languages (e.g. JavaScript), or having alternative extensions (e.g. `.php5`), or even compiled binaries.

**This PR** adds _execute permission_ check instead of filtering files by known extensions.