### PR TITLE
Only confirm quitting if connections are active

### DIFF
--- a/Sources/App/Classes/Controllers/TXMasterController.m
+++ b/Sources/App/Classes/Controllers/TXMasterController.m
@@ -65,6 +65,7 @@
 #import "TXMenuControllerPrivate.h"
 #import "TXWindowControllerPrivate.h"
 #import "TXMasterControllerPrivate.h"
+#import "IRCClient.h"
 
 #if TEXTUAL_BUILT_WITH_HOCKEYAPP_SDK_ENABLED == 1
 #import <HockeySDK/HockeySDK.h>
@@ -409,7 +410,14 @@ NS_ASSUME_NONNULL_BEGIN
 		return YES;
 	}
 
-	if ([TPCPreferences confirmQuit]) {
+    BOOL stillConnected = NO;
+    for (IRCClient *u in worldController().clientList) {
+        if (u.isConnecting || u.isConnected) {
+            stillConnected = YES;
+        }
+    }
+
+	if ([TPCPreferences confirmQuit] && stillConnected) {
 		BOOL result = [TDCAlert modalAlertWithMessage:TXTLS(@"Prompts[77u-vp]")
 												title:TXTLS(@"Prompts[6vj-2p]")
 										defaultButton:TXTLS(@"Prompts[1bf-k0]")

--- a/Sources/App/Classes/Controllers/TXMasterController.m
+++ b/Sources/App/Classes/Controllers/TXMasterController.m
@@ -410,12 +410,12 @@ NS_ASSUME_NONNULL_BEGIN
 		return YES;
 	}
 
-    BOOL stillConnected = NO;
-    for (IRCClient *u in worldController().clientList) {
-        if (u.isConnecting || u.isConnected) {
-            stillConnected = YES;
-        }
-    }
+	BOOL stillConnected = NO;
+	for (IRCClient *u in worldController().clientList) {
+		if (u.isConnecting || u.isConnected) {
+			stillConnected = YES;
+		}
+	}
 
 	if ([TPCPreferences confirmQuit] && stillConnected) {
 		BOOL result = [TDCAlert modalAlertWithMessage:TXTLS(@"Prompts[77u-vp]")
@@ -519,7 +519,7 @@ NS_ASSUME_NONNULL_BEGIN
 	/* We want certain things to 100% happen before the app completely closes.
 	 This block that is performed below loops until all these actions are completed.
 	 Notable actions: gracefully leaving IRC, saving historic logs, and closing
-	 down iCloud syncing (if applicable). */ 
+	 down iCloud syncing (if applicable). */
 	XRPerformBlockAsynchronouslyOnGlobalQueueWithPriority(^{
 		do {
 			/* We wait until this value reaches zero so that

--- a/Sources/App/Resources/User Interface/en.lproj/TDCPreferences.xib
+++ b/Sources/App/Resources/User Interface/en.lproj/TDCPreferences.xib
@@ -279,8 +279,8 @@
             <rect key="frame" x="0.0" y="0.0" width="589" height="236"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="bKt-Ac-1I2">
-                    <rect key="frame" x="58" y="190" width="410" height="18"/>
-                    <buttonCell key="cell" type="check" title="Request confirmation before quitting Textual if connections are open" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="XAa-aA-vKv">
+                    <rect key="frame" x="58" y="190" width="274" height="18"/>
+                    <buttonCell key="cell" type="check" title="Request confirmation before quitting Textual" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="XAa-aA-vKv">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="titleBar" size="12"/>
                     </buttonCell>

--- a/Sources/App/Resources/User Interface/en.lproj/TDCPreferences.xib
+++ b/Sources/App/Resources/User Interface/en.lproj/TDCPreferences.xib
@@ -279,8 +279,8 @@
             <rect key="frame" x="0.0" y="0.0" width="589" height="236"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="bKt-Ac-1I2">
-                    <rect key="frame" x="58" y="190" width="274" height="18"/>
-                    <buttonCell key="cell" type="check" title="Request confirmation before quitting Textual" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="XAa-aA-vKv">
+                    <rect key="frame" x="58" y="190" width="410" height="18"/>
+                    <buttonCell key="cell" type="check" title="Request confirmation before quitting Textual if connections are open" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="XAa-aA-vKv">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="titleBar" size="12"/>
                     </buttonCell>


### PR DESCRIPTION
Hello!

This patch fixes a tiny thing that's been bugging me for a while now: Textual always asks for confirmation when quitting, even when there are no connections open and quitting isn't a destructive action. I've never written Objective-C before, so I don't know if this patch is the "most correct" way of solving the problem. I did test it though, and it builds and runs without errors or unexpected behavior.

Is this a change you'd be willing to accept?

(P.S. Thanks for developing Textual! It's my favorite IRC client.)