### PR TITLE
Adopt `supported-color-schemes` CSS property for styles

### DIFF
--- a/Sources/App/Resources/Styling/Bundled Styles/Astria/design.css
+++ b/Sources/App/Resources/Styling/Bundled Styles/Astria/design.css
@@ -5,6 +5,10 @@
 
 /* Basic Body Structure */
 
+:root {
+	supported-color-schemes: dark;
+}
+
 * {
 	margin: 0;
 	padding: 0;

--- a/Sources/App/Resources/Styling/Bundled Styles/Equinox/design.css
+++ b/Sources/App/Resources/Styling/Bundled Styles/Equinox/design.css
@@ -4,6 +4,10 @@
 
 /* Basic Body Structure */
 
+:root {
+	supported-color-schemes: dark;
+}
+
 * {
   margin: 0;
   padding: 0;

--- a/Sources/App/Resources/Styling/Bundled Styles/Sapientia/design.css
+++ b/Sources/App/Resources/Styling/Bundled Styles/Sapientia/design.css
@@ -5,6 +5,10 @@
 
 /* Basic Body Structure - Sapientia 1.3 */
 
+:root {
+	supported-color-schemes: dark;
+}
+
 * {
 	margin: 0;
 	padding: 0;

--- a/Sources/App/Resources/Styling/Bundled Styles/Simplified Dark/design.css
+++ b/Sources/App/Resources/Styling/Bundled Styles/Simplified Dark/design.css
@@ -5,6 +5,10 @@
 
 /* Basic Body Structure */
 
+:root {
+	supported-color-schemes: dark;
+}
+
 * {
 	margin: 0;
 	padding: 0;

--- a/Sources/App/Resources/Styling/Bundled Styles/Simplified Light/design.css
+++ b/Sources/App/Resources/Styling/Bundled Styles/Simplified Light/design.css
@@ -5,6 +5,10 @@
 
 /* Basic Body Structure */
 
+:root {
+	supported-color-schemes: light;
+}
+
 * {
 	margin: 0;
 	padding: 0;

--- a/Sources/App/Resources/Styling/Bundled Styles/Sulaco/design.css
+++ b/Sources/App/Resources/Styling/Bundled Styles/Sulaco/design.css
@@ -5,6 +5,10 @@
 
 /* Basic Structure */
 
+:root {
+	supported-color-schemes: dark;
+}
+
 body {
 	background: #222;
 	color: #cfcfcf;

--- a/Sources/App/Resources/Styling/Bundled Styles/Tomorrow Night (Eighties)/design.css
+++ b/Sources/App/Resources/Styling/Bundled Styles/Tomorrow Night (Eighties)/design.css
@@ -11,6 +11,10 @@
 
 /* @group Basic Body Structure */
 
+:root {
+	supported-color-schemes: dark;
+}
+
 * {
 	margin: 0;
 	padding: 0;

--- a/Sources/App/Resources/Styling/Bundled Styles/Tomorrow/design.css
+++ b/Sources/App/Resources/Styling/Bundled Styles/Tomorrow/design.css
@@ -11,6 +11,10 @@
 
 /* @group Basic Body Structure */
 
+:root {
+	supported-color-schemes: light;
+}
+
 * {
 	margin: 0;
 	padding: 0;

--- a/Sources/App/Resources/Styling/Bundled Styles/Total Sublime/design.css
+++ b/Sources/App/Resources/Styling/Bundled Styles/Total Sublime/design.css
@@ -5,6 +5,10 @@
 
 /* Basic Body Structure */
 
+:root {
+	supported-color-schemes: dark;
+}
+
 * {
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
This will get the proper WebKit scrollbar appearance in 10.14.4 betas.