### PR TITLE
Change Accessibility Title of App to "Textual"

### DIFF
--- a/Sources/App/Resources/Language Files/en.lproj/Accessibility.strings
+++ b/Sources/App/Resources/Language Files/en.lproj/Accessibility.strings
@@ -45,6 +45,6 @@
 
 "9sn-xp" = "Query with User %@";
 
-"k79-1a" = "Main Window"; // Main window title description
+"k79-1a" = "Textual"; // Main window title description
 
 "wbj-gr" = "Alert dialog %@";


### PR DESCRIPTION
Textual's current accessibility title of "Main Window" is vague at best and misleading at worst.  This pull request changes it to "Textual", which is much more clear and useful.

Furthermore, some apps, like Contexts (https://contexts.co), display the accessibility title alongside the accessibility title from other app's windows, making "Main Window" all the more confusing.