### PR TITLE
Fix message display for other channel prefixes

### DIFF
--- a/Sources/App/Classes/IRC/IRCISupportInfo.m
+++ b/Sources/App/Classes/IRC/IRCISupportInfo.m
@@ -103,7 +103,7 @@ ClassWithDesignatedInitializerInitMethod
 	self.networkName = nil;
 	self.networkNameFormatted = nil;
 
-	self.channelNamePrefixes = @[@"#"];
+	self.channelNamePrefixes = @[@"&", @"#", @"+", @"!"];
 
 	self.maximumModeCount = TXMaximumNodesPerModeCommand;
 	self.maximumNicknameLength = IRCProtocolDefaultNicknameMaximumLength;


### PR DESCRIPTION
By default, channels are recognised only if prefixed with the '#'
character. However, IRC servers support channels prefixed with other
characters: '&', '#', '+' or '!'.

See RFC references detailing channel prefixes:
https://tools.ietf.org/html/rfc1459#section-1.3
https://tools.ietf.org/html/rfc2811#section-2.1
https://tools.ietf.org/html/rfc2812#section-1.3

This fixes an issue where Textual sends messages to these channels to a
private window instead of the channel window.