### PR TITLE
nil-check paths passed to buildPathArray in THOPluginManager

### DIFF
--- a/Sources/App/Classes/Helpers/Plugin Architecture/THOPluginManager.m
+++ b/Sources/App/Classes/Helpers/Plugin Architecture/THOPluginManager.m
@@ -89,7 +89,7 @@ NSString * const THOPluginManagerFinishedLoadingPluginsNotification = @"THOPlugi
 
 	NSArray *pathsToLoad =
 	[RZFileManager() buildPathArray:
-		[TPCPathInfo customExtensions],
+		[TPCPathInfo customExtensions] ?: @"",
 		[TPCPathInfo bundledExtensions],
 		nil];
 
@@ -224,7 +224,7 @@ NSString * const THOPluginManagerFinishedLoadingPluginsNotification = @"THOPlugi
 
 	NSArray *scriptPaths =
 	[RZFileManager() buildPathArray:
-		[TPCPathInfo customScripts],
+		[TPCPathInfo customScripts] ?: @"",
 		[TPCPathInfo bundledScripts],
 		nil];
 
@@ -273,7 +273,7 @@ NSString * const THOPluginManagerFinishedLoadingPluginsNotification = @"THOPlugi
 
 - (NSArray<NSString *> *)listOfForbiddenCommandNames
 {
-	/* List of commands that cannot be used as the name of a script 
+	/* List of commands that cannot be used as the name of a script
 	 because they would conflict with the commands defined by one or
 	 more standard (RFC) */
 	static NSArray<NSString *> *cachedValue = nil;
@@ -374,7 +374,7 @@ NSString * const THOPluginManagerFinishedLoadingPluginsNotification = @"THOPlugi
 {
 	NSParameterAssert(bundles != nil);
 
-	/* Append the current version to the suppression key so that updates 
+	/* Append the current version to the suppression key so that updates
 	 aren't refused forever. Only until the next verison of Textual is out. */
 	NSString *suppressionKey =
 	[@"plugin_manager_extension_update_dialog_"


### PR DESCRIPTION
After upgrading from Textual 7.0.6 to 7.1.2, Textual crashes when opening the preferences dialogue. Looking at the crash data, [TPCPathInfo customScripts] returns nil.

I didn't check why it's returning nil, but the return type of that function is marked as 'nullable' anyways.

1- buildPathArray is a variadic function, that stops at the first nil argument it encounters
2- buildPathArray  also has an assertion around the first argument not being nil

Meaning that we can't pass null values to it. Checking the code of buildPathArray, it will skip empty strings, so replace nil strings with empty ones. Another option would be to flip the arguments around, since bundledScripts is not nullable. Went for the null-check since I don't know if the order matters.