### PR TITLE
Disable library validation for XPC services

### DIFF
--- a/XPC Services/Historic Log File Manager/Configurations/Sandbox/Release.entitlements
+++ b/XPC Services/Historic Log File Manager/Configurations/Sandbox/Release.entitlements
@@ -8,5 +8,7 @@
 	<array>
 		<string>com.codeux.apps.textual</string>
 	</array>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>

--- a/XPC Services/IRC Remote Connection Manager/Configurations/Sandbox/Release.entitlements
+++ b/XPC Services/IRC Remote Connection Manager/Configurations/Sandbox/Release.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.temporary-exception.shared-preference.read-write</key>


### PR DESCRIPTION
Follow up to a0f366f which is needed to allow building a functional
version of Textual without an official Apple developer identity. Network
and logging libraries will crash at runtime with errors referencing
missing Team ID data and platform binary signing unless the sub-module
builds are configured to disable enforcement of library validation.