### PR TITLE
Support arm64 objc_msgSend ABI

### DIFF
--- a/Sources/App/Classes/IRC/IRCClient.m
+++ b/Sources/App/Classes/IRC/IRCClient.m
@@ -3527,7 +3527,7 @@ DESIGNATED_INITIALIZER_EXCEPTION_BODY_END
 
 				IRCClientConfigMutable *mutableClientConfig = [client.config mutableCopy];
 
-				(void)objc_msgSend(mutableClientConfig, selector, featureValue);
+				((void (*)(id, SEL, BOOL))objc_msgSend)(mutableClientConfig, selector, featureValue);
 
 				client.config = mutableClientConfig;
 			};

--- a/Sources/App/Classes/IRC/IRCConnection.m
+++ b/Sources/App/Classes/IRC/IRCConnection.m
@@ -368,7 +368,7 @@ ClassWithDesignatedInitializerInitMethod
 	if ([self.trustPanel respondsToSelector:dismissSelector]) {
 		self.trustPanelDoNotInvokeCompletionBlock = YES;
 
-		(void)objc_msgSend(self.trustPanel, dismissSelector, NSModalResponseCancel);
+		((void (*)(id, SEL, const NSModalResponse))objc_msgSend)(self.trustPanel, dismissSelector, NSModalResponseCancel);
 	}
 }
 

--- a/Sources/App/Classes/Library/TLOKeyEventHandler.m
+++ b/Sources/App/Classes/Library/TLOKeyEventHandler.m
@@ -162,7 +162,7 @@ ClassWithDesignatedInitializerInitMethod
 		NSString *selectorName = codeMap[@(e.keyCode)];
 
 		if (selectorName) {
-			objc_msgSend(self.target, NSSelectorFromString(selectorName), e);
+			((void (*)(id, SEL, NSEvent *))objc_msgSend)(self.target, NSSelectorFromString(selectorName), e);
 
 			return YES;
 		}
@@ -177,7 +177,7 @@ ClassWithDesignatedInitializerInitMethod
 			NSString *selectorName = characterMap[@([characterString characterAtIndex:0])];
 
 			if (selectorName) {
-				objc_msgSend(self.target, NSSelectorFromString(selectorName), e);
+				((void (*)(id, SEL, NSEvent *))objc_msgSend)(self.target, NSSelectorFromString(selectorName), e);
 
 				return YES;
 			}

--- a/Sources/App/Classes/Views/Channel View/TVCLogScriptEventSink.m
+++ b/Sources/App/Classes/Views/Channel View/TVCLogScriptEventSink.m
@@ -136,9 +136,9 @@ ClassWithDesignatedInitializerInitMethod
 			argument = [self.webView webScriptObjectToCommon:argument];
 		}
 
-		(void)objc_msgSend(self, handlerSelector, argument, self.webView);
+		((void (*)(id, SEL, NSArray *, TVCLogView *))objc_msgSend)(self, handlerSelector, argument, self.webView);
 	} else {
-		(void)objc_msgSend(self, handlerSelector, nil, self.webView);
+		((void (*)(id, SEL, NSArray *, TVCLogView *))objc_msgSend)(self, handlerSelector, nil, self.webView);
 	}
 
 	return @(YES);
@@ -208,7 +208,7 @@ ClassWithDesignatedInitializerInitMethod
 		return;
 	}
 
-	(void)objc_msgSend(self, handlerSelector, message.body, message.webView);
+	((void (*)(id, SEL, id, WKWebView *))objc_msgSend)(self, handlerSelector, message.body, message.webView);
 }
 
 - (void)processInputData:(id)inputData
@@ -358,7 +358,7 @@ ClassWithDesignatedInitializerInitMethod
 
 	context.completionBlock = completionBlock;
 
-	(void)objc_msgSend(self, selector, context);
+	((void (*)(id, SEL, TVCLogScriptEventSinkContext *))objc_msgSend)(self, selector, context);
 }
 
 + (void)logToJavaScriptConsole:(NSString *)message inWebView:(TVCLogView *)webView, ...

--- a/Sources/App/Classes/Views/Channel View/TVCLogViewInternalWK1.m
+++ b/Sources/App/Classes/Views/Channel View/TVCLogViewInternalWK1.m
@@ -72,7 +72,7 @@ static TVCLogPolicy *_sharedWebPolicy = nil;
 		_sharedWebViewPreferences.usesPageCache = NO;
 
 		if ([_sharedWebViewPreferences respondsToSelector:@selector(setShouldRespectImageOrientation:)]) {
-			(void)objc_msgSend(_sharedWebViewPreferences, @selector(setShouldRespectImageOrientation:), YES);
+			((void (*)(id, SEL, BOOL))objc_msgSend)(_sharedWebViewPreferences, @selector(setShouldRespectImageOrientation:), YES);
 		}
 
 		_sharedWebPolicy = [TVCLogPolicy new];

--- a/Sources/App/Classes/Views/Channel View/TVCLogViewInternalWK2.m
+++ b/Sources/App/Classes/Views/Channel View/TVCLogViewInternalWK2.m
@@ -299,7 +299,7 @@ create_normal_pool:
 	}
 
 	if ([self respondsToSelector:@selector(_findString:options:maxCount:)]) {
-		(void)objc_msgSend(self, @selector(_findString:options:maxCount:), searchString, findOptions, 1);
+		((void (*)(id, SEL, NSString *, _WKFindOptions, int))objc_msgSend)(self, @selector(_findString:options:maxCount:), searchString, findOptions, 1);
 	}
 }
 


### PR DESCRIPTION
Textual builds on Apple Silicon. These were the only code changes I needed to make to support the arm64 `objc_msgSend` ABI (on x86_64 it uses `va_arg`, on arm64 they are passed directly through `X0`... etc.)

For `EncryptionKit.framework` I used MacPorts to build the dependencies: `sudo port install libgcrypt libgpg-error libotr` and then modified the Xcode project to link against those libraries on disk.

From there, change everything to use the `Apple Silicon and Intel` (Universal) configuration and it builds.

Each of these changes should be wrapped in an `#if OBJC_OLD_DISPATCH_PROTOTYPES` for backwards compatibility with x86_64 configurations.