### PR TITLE
Change the default NICKLEN value to 31

### DIFF
--- a/Sources/App/Classes/Headers/IRC.h
+++ b/Sources/App/Classes/Headers/IRC.h
@@ -44,5 +44,5 @@
 
 #define TXMaximumNodesPerModeCommand				4
 
-#define IRCProtocolDefaultNicknameMaximumLength			9
+#define IRCProtocolDefaultNicknameMaximumLength			31
 


### PR DESCRIPTION
There's some fun history here. The original draft proposal used 9 as an example. This is where I think the default value here came from.

Unfortunately, I don't know if this value makes much sense. The full text of the spec says "The NICKLEN parameter specifies the maximum length of a nickname that a client can use.  A client elsewhere on the network MAY use a nick length of higher value."

This would seem to mean that using this value to validate whether something is a nick or not may lead to false negatives. Increasing it will be a good stop-gap, but based on the wording of the draft RFC, I'm not sure if it's a great check to be using to validate nicks at all.

https://tools.ietf.org/html/draft-hardy-irc-isupport-00#section-4.14

Additionally, it seems as though most servers default to 30-31 (though I don't know where this data originally came from). https://modern.ircdocs.horse/#nicklen-parameter I set this default to the larger of the two for good measure.

Just so there's background info on why I'm hoping for this to be merged: [soju](https://github.com/emersion/soju) doesn't send a NICKLEN value with ISUPPORT (yet), so textual defaults to `IRCProtocolDefaultNicknameMaximumLength` which ends up being really short, especially if you tack on network names (soju can have multiple networks on a single bouncer connection, so belak would become belak/freenode).

The long term fix is to also update soju to send a value for NICKLEN, but I think this change is still worthwhile.