### PR TITLE
Adapt code to support Arm-based Macs

### DIFF
--- a/Sources/App/Classes/IRC/IRCClient.m
+++ b/Sources/App/Classes/IRC/IRCClient.m
@@ -3527,7 +3527,12 @@ DESIGNATED_INITIALIZER_EXCEPTION_BODY_END
 
 				IRCClientConfigMutable *mutableClientConfig = [client.config mutableCopy];
 
-				(void)objc_msgSend(mutableClientConfig, selector, featureValue);
+				NSMethodSignature *signature = [mutableClientConfig methodSignatureForSelector:selector];
+				NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+				[invocation setTarget:mutableClientConfig];
+				[invocation setSelector:selector];
+				[invocation setArgument:&featureValue atIndex:2];
+				[invocation invoke];
 
 				client.config = mutableClientConfig;
 			};

--- a/Sources/App/Classes/IRC/IRCConnection.m
+++ b/Sources/App/Classes/IRC/IRCConnection.m
@@ -368,7 +368,13 @@ ClassWithDesignatedInitializerInitMethod
 	if ([self.trustPanel respondsToSelector:dismissSelector]) {
 		self.trustPanelDoNotInvokeCompletionBlock = YES;
 
-		(void)objc_msgSend(self.trustPanel, dismissSelector, NSModalResponseCancel);
+		NSMethodSignature *signature = [self.trustPanel methodSignatureForSelector:dismissSelector];
+		NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+		[invocation setTarget:self.trustPanel];
+		[invocation setSelector:dismissSelector];
+		NSModalResponse cancel = NSModalResponseCancel;
+		[invocation setArgument:&cancel atIndex:2];
+		[invocation invoke];
 	}
 }
 

--- a/Sources/App/Classes/Library/TLOKeyEventHandler.m
+++ b/Sources/App/Classes/Library/TLOKeyEventHandler.m
@@ -162,7 +162,13 @@ ClassWithDesignatedInitializerInitMethod
 		NSString *selectorName = codeMap[@(e.keyCode)];
 
 		if (selectorName) {
-			objc_msgSend(self.target, NSSelectorFromString(selectorName), e);
+			SEL sel = NSSelectorFromString(selectorName);
+			NSMethodSignature *signature = [self.target methodSignatureForSelector:sel];
+			NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+			[invocation setTarget:self.target];
+			[invocation setSelector:sel];
+			[invocation setArgument:&e atIndex:2];
+			[invocation invoke];
 
 			return YES;
 		}
@@ -177,7 +183,13 @@ ClassWithDesignatedInitializerInitMethod
 			NSString *selectorName = characterMap[@([characterString characterAtIndex:0])];
 
 			if (selectorName) {
-				objc_msgSend(self.target, NSSelectorFromString(selectorName), e);
+				SEL sel = NSSelectorFromString(selectorName);
+				NSMethodSignature *signature = [self.target methodSignatureForSelector:sel];
+				NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+				[invocation setTarget:self.target];
+				[invocation setSelector:sel];
+				[invocation setArgument:&e atIndex:2];
+				[invocation invoke];
 
 				return YES;
 			}

--- a/Sources/App/Classes/Views/Channel View/TVCLogScriptEventSink.m
+++ b/Sources/App/Classes/Views/Channel View/TVCLogScriptEventSink.m
@@ -129,17 +129,23 @@ ClassWithDesignatedInitializerInitMethod
 		return @(NO);
 	}
 
+	id argument = nil;
 	if (arguments && arguments.count > 0) {
-		id argument = arguments[0];
+		argument = arguments[0];
 
 		if ([argument isKindOfClass:[WebScriptObject class]]) {
 			argument = [self.webView webScriptObjectToCommon:argument];
 		}
-
-		(void)objc_msgSend(self, handlerSelector, argument, self.webView);
-	} else {
-		(void)objc_msgSend(self, handlerSelector, nil, self.webView);
 	}
+
+	NSMethodSignature *signature = [self methodSignatureForSelector:handlerSelector];
+	NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+	[invocation setTarget:self];
+	[invocation setSelector:handlerSelector];
+	[invocation setArgument:&argument atIndex:2];
+	TVCLogView *webView = self.webView;
+	[invocation setArgument:&webView atIndex:3];
+	[invocation invoke];
 
 	return @(YES);
 }
@@ -208,7 +214,15 @@ ClassWithDesignatedInitializerInitMethod
 		return;
 	}
 
-	(void)objc_msgSend(self, handlerSelector, message.body, message.webView);
+	NSMethodSignature *signature = [self methodSignatureForSelector:handlerSelector];
+	NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+	[invocation setTarget:self];
+	[invocation setSelector:handlerSelector];
+	id body = message.body;
+	[invocation setArgument:&body atIndex:2];
+	WKWebView *webView = message.webView;
+	[invocation setArgument:&webView atIndex:3];
+	[invocation invoke];
 }
 
 - (void)processInputData:(id)inputData
@@ -358,7 +372,12 @@ ClassWithDesignatedInitializerInitMethod
 
 	context.completionBlock = completionBlock;
 
-	(void)objc_msgSend(self, selector, context);
+	NSMethodSignature *signature = [self methodSignatureForSelector:selector];
+	NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+	[invocation setTarget:self];
+	[invocation setSelector:selector];
+	[invocation setArgument:&context atIndex:2];
+	[invocation invoke];
 }
 
 + (void)logToJavaScriptConsole:(NSString *)message inWebView:(TVCLogView *)webView, ...

--- a/Sources/App/Classes/Views/Channel View/TVCLogViewInternalWK1.m
+++ b/Sources/App/Classes/Views/Channel View/TVCLogViewInternalWK1.m
@@ -71,8 +71,15 @@ static TVCLogPolicy *_sharedWebPolicy = nil;
 		_sharedWebViewPreferences.cacheModel = WebCacheModelDocumentViewer;
 		_sharedWebViewPreferences.usesPageCache = NO;
 
-		if ([_sharedWebViewPreferences respondsToSelector:@selector(setShouldRespectImageOrientation:)]) {
-			(void)objc_msgSend(_sharedWebViewPreferences, @selector(setShouldRespectImageOrientation:), YES);
+		SEL sel = @selector(setShouldRespectImageOrientation:);
+		if ([_sharedWebViewPreferences respondsToSelector:sel]) {
+			NSMethodSignature *signature = [_sharedWebViewPreferences methodSignatureForSelector:sel];
+			NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+			[invocation setTarget:_sharedWebViewPreferences];
+			[invocation setSelector:sel];
+			BOOL yes = YES;
+			[invocation setArgument:&yes atIndex:2];
+			[invocation invoke];
 		}
 
 		_sharedWebPolicy = [TVCLogPolicy new];

--- a/Sources/App/Classes/Views/Channel View/TVCLogViewInternalWK2.m
+++ b/Sources/App/Classes/Views/Channel View/TVCLogViewInternalWK2.m
@@ -298,8 +298,17 @@ create_normal_pool:
 		findOptions |= _WKFindOptionsBackwards;
 	}
 
-	if ([self respondsToSelector:@selector(_findString:options:maxCount:)]) {
-		(void)objc_msgSend(self, @selector(_findString:options:maxCount:), searchString, findOptions, 1);
+	SEL sel = @selector(_findString:options:maxCount:);
+	if ([self respondsToSelector:sel]) {
+		NSMethodSignature *signature = [self methodSignatureForSelector:sel];
+		NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+		[invocation setTarget:self];
+		[invocation setSelector:sel];
+		[invocation setArgument:&searchString atIndex:2];
+		[invocation setArgument:&findOptions atIndex:3];
+		int one = 1;
+		[invocation setArgument:&one atIndex:4];
+		[invocation invoke];
 	}
 }
 

--- a/Textual.xcworkspace/contents.xcworkspacedata
+++ b/Textual.xcworkspace/contents.xcworkspacedata
@@ -14,7 +14,7 @@
          location = "group:Frameworks/Encryption Kit/Encryption Kit.xcodeproj">
       </FileRef>
       <FileRef
-         location = "group:/Users/michael/Projects/Textual/Frameworks/Auto Hyperlinks/Hyperlink Processor.xcodeproj">
+         location = "group:Frameworks/Auto Hyperlinks/Hyperlink Processor.xcodeproj">
       </FileRef>
    </Group>
    <Group

--- a/XPC Services/IRC Remote Connection Manager/Classes/IRC/IRCConnectionSocketNWF.swift
+++ b/XPC Services/IRC Remote Connection Manager/Classes/IRC/IRCConnectionSocketNWF.swift
@@ -108,7 +108,12 @@ final class ConnectionSocketNWF: ConnectionSocket, ConnectionSocketProtocol
 												includeDeprecated: (config.connectionPrefersModernCiphersOnly == false))
 
 			for cipherSuite in cipherSuites {
-				sec_protocol_options_add_tls_ciphersuite(secOptions, cipherSuite.uint32Value as SSLCipherSuite)
+#if ((os(iOS) && !targetEnvironment(macCatalyst)) || (os(macOS) && arch(arm64)))
+				let coercedSuite = cipherSuite.uint16Value as SSLCipherSuite;
+#else
+				let coercedSuite = cipherSuite.uint32Value as SSLCipherSuite;
+#endif
+				sec_protocol_options_add_tls_ciphersuite(secOptions, coercedSuite);
 			}
 		}
 


### PR DESCRIPTION
This adds the necessary changes to the code itself to support Arm-based Macs.

Note that I have not included changes to the build system, so it still only builds x86_64 binaries. Building arm64 binaries requires Encryption Kit to do the same, but it currently only supports x86_64. Switching it to arm64 is easy enough locally (I have a local arm64-only build that I've verified can connect to an IRC server and join a channel), but building it as a universal binary is harder due to the 3rd-party autoconf-using libraries built using -arch x86_64; buildLibraries.sh will need an overhaul to build all libraries as both x86_64 and arm64 then use lipo to combine them, but once that is done Textual should be ready to build as a universal binary.

This is a more complete, cleaner, and non-build-breaking due to leaving ARCHS alone, alternative to #544.
