### PR TITLE
Add M1 Macs to System Profiler Plugin

### DIFF
--- a/Sources/App/Classes/IRC/IRCClient.m
+++ b/Sources/App/Classes/IRC/IRCClient.m
@@ -4220,6 +4220,10 @@ DESIGNATED_INITIALIZER_EXCEPTION_BODY_END
 
 			[mainWindow() select:query];
 
+			if (stringIn.length > 0) {
+				[self sendText:stringIn asCommand:IRCRemoteCommandPrivmsg toChannel:query];
+			}
+
 			break;
 		}
 		case IRCLocalCommandQuote: // Command: QUOTE


### PR DESCRIPTION
Realized these weren't in there and decided to add them.

Also, I cleaned up an erroneous space in a MacBookAir model.