### PR TITLE
honor user-specified full-screen presentation options

### DIFF
--- a/Sources/App/Classes/Views/Main Window/TVCMainWindow.m
+++ b/Sources/App/Classes/Views/Main Window/TVCMainWindow.m
@@ -521,7 +521,7 @@ NSString * const TVCMainWindowSelectionChangedNotification = @"TVCMainWindowSele
 
 - (NSApplicationPresentationOptions)window:(NSWindow *)window willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions
 {
-	return (NSApplicationPresentationFullScreen | NSApplicationPresentationHideDock | NSApplicationPresentationAutoHideMenuBar);
+	return proposedOptions;
 }
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification


### PR DESCRIPTION
Right now on a notchbook, if you disable the global preference "Automatically hide menubar in fullscreen", Textual ignores this and automatically hides the menubar no matter what.  Personally I leave this off when using my laptop without an external display (because due to an Apple bug, hiding the menu bar disables the ⌘? shortcut which allows me to type the name of menu items, and "⌘? Connect ⬇️⏎" is a pretty common thing for me to do, *particularly* when untethered).

Here's one possible fix; I've tested it locally and it fixes it for me. I'm not sure that this is the one you'd actually want to use, since possibly this method was overridden for a reason, but paying attention to the input `proposedOptions` mask seems like it's probably a good idea in *some* way.