### PR TITLE
Add SHA-512 digest to client certificate page

### DIFF
--- a/Sources/App/Classes/Dialogs/TDCServerPropertiesSheet.m
+++ b/Sources/App/Classes/Dialogs/TDCServerPropertiesSheet.m
@@ -105,6 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) IBOutlet NSButton *clientCertificateMD5FingerprintCopyButton;
 @property (nonatomic, weak) IBOutlet NSButton *clientCertificateSHA1FingerprintCopyButton;
 @property (nonatomic, weak) IBOutlet NSButton *clientCertificateSHA2FingerprintCopyButton;
+@property (nonatomic, weak) IBOutlet NSButton *clientCertificateSHA512FingerprintCopyButton;
 @property (nonatomic, weak) IBOutlet NSButton *connectionIPv4AddressTypeCheck;
 @property (nonatomic, weak) IBOutlet NSButton *connectionIPv6AddressTypeCheck;
 @property (nonatomic, weak) IBOutlet NSButton *connectionDefaultddressTypeCheck;
@@ -136,6 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) IBOutlet NSTextField *clientCertificateMD5FingerprintField;
 @property (nonatomic, weak) IBOutlet NSTextField *clientCertificateSHA1FingerprintField;
 @property (nonatomic, weak) IBOutlet NSTextField *clientCertificateSHA2FingerprintField;
+@property (nonatomic, weak) IBOutlet NSTextField *clientCertificateSHA512FingerprintField;
 @property (nonatomic, weak) IBOutlet NSTextField *nicknamePasswordTextField;
 @property (nonatomic, weak) IBOutlet NSTextField *proxyPasswordTextField;
 @property (nonatomic, weak) IBOutlet NSTextField *proxyUsernameTextField;
@@ -208,6 +210,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (IBAction)onClientCertificateResetRequested:(id)sender;
 - (IBAction)onClientCertificateChangeRequested:(id)sender;
+- (IBAction)onClientCertificateFingerprintSHA512CopyRequested:(id)sender;
 - (IBAction)onClientCertificateFingerprintSHA2CopyRequested:(id)sender;
 - (IBAction)onClientCertificateFingerprintSHA1CopyRequested:(id)sender;
 - (IBAction)onClientCertificateFingerprintMD5CopyRequested:(id)sender;
@@ -1514,6 +1517,15 @@ TEXTUAL_IGNORE_DEPRECATION_END
 #pragma mark -
 #pragma mark SSL Certificate
 
+- (void)onClientCertificateFingerprintSHA512CopyRequested:(id)sender
+{
+    NSString *fingerprint = self.clientCertificateSHA512FingerprintField.stringValue;
+
+    NSString *command = [NSString stringWithFormat:@"/msg NickServ cert add %@", fingerprint];
+
+    RZPasteboard().stringContent = command;
+}
+
 - (void)onClientCertificateFingerprintSHA2CopyRequested:(id)sender
 {
 	NSString *fingerprint = self.clientCertificateSHA2FingerprintField.stringValue;
@@ -1542,6 +1554,7 @@ TEXTUAL_IGNORE_DEPRECATION_END
 }
 
 - (void)readClientCertificateCommonName:(NSString **)commonNameOut
+					  sha512Fingerprint:(NSString **)sha512FingerprintOut
 						sha2Fingerprint:(NSString **)sha2FingerprintOut
 						sha1Fingerprint:(NSString **)sha1FingerprintOut
 						 md5Fingerprint:(NSString **)md5FingerprintOut
@@ -1587,6 +1600,7 @@ TEXTUAL_IGNORE_DEPRECATION_END
 	if (certificateDataRef) {
 		NSData *certificateData = (__bridge NSData *)certificateDataRef;
 
+		*sha512FingerprintOut = certificateData.sha512;
 		*sha2FingerprintOut = certificateData.sha256;
 		*sha1FingerprintOut = certificateData.sha1;
 		*md5FingerprintOut = certificateData.md5;
@@ -1651,11 +1665,13 @@ TEXTUAL_IGNORE_DEPRECATION_END
 {
 	NSString *commonName = nil;
 
+	NSString *sha512Fingerprint = nil;
 	NSString *sha2Fingerprint = nil;
 	NSString *sha1Fingerprint = nil;
 	NSString *md5Fingerprint = nil;
 
 	[self readClientCertificateCommonName:&commonName
+						sha512Fingerprint:&sha512Fingerprint
 						  sha2Fingerprint:&sha2Fingerprint
 						  sha1Fingerprint:&sha1Fingerprint
 						   md5Fingerprint:&md5Fingerprint];
@@ -1664,13 +1680,15 @@ TEXTUAL_IGNORE_DEPRECATION_END
 
 	if (hasNoCertificate) {
 		self.clientCertificateCommonNameField.stringValue = TXTLS(@"TDCServerPropertiesSheet[6xz-ec]");
-
+		
+		self.clientCertificateSHA512FingerprintField.stringValue = TXTLS(@"TDCServerPropertiesSheet[6xz-ec]");
 		self.clientCertificateSHA2FingerprintField.stringValue = TXTLS(@"TDCServerPropertiesSheet[6xz-ec]");
 		self.clientCertificateSHA1FingerprintField.stringValue = TXTLS(@"TDCServerPropertiesSheet[6xz-ec]");
 		self.clientCertificateMD5FingerprintField.stringValue = TXTLS(@"TDCServerPropertiesSheet[6xz-ec]");
 	} else {
 		self.clientCertificateCommonNameField.stringValue = commonName;
 
+		self.clientCertificateSHA512FingerprintField.stringValue = sha512Fingerprint.uppercaseString;
 		self.clientCertificateSHA2FingerprintField.stringValue = sha2Fingerprint.uppercaseString;
 		self.clientCertificateSHA1FingerprintField.stringValue = sha1Fingerprint.uppercaseString;
 		self.clientCertificateMD5FingerprintField.stringValue = md5Fingerprint.uppercaseString;
@@ -1678,6 +1696,7 @@ TEXTUAL_IGNORE_DEPRECATION_END
 
 	self.clientCertificateResetCertificateButton.enabled = (hasNoCertificate == NO);
 
+	self.clientCertificateSHA512FingerprintCopyButton.enabled = (hasNoCertificate == NO);
 	self.clientCertificateSHA2FingerprintCopyButton.enabled = (hasNoCertificate == NO);
 	self.clientCertificateSHA1FingerprintCopyButton.enabled = (hasNoCertificate == NO);
 	self.clientCertificateMD5FingerprintCopyButton.enabled = (hasNoCertificate == NO);

--- a/Sources/App/Resources/User Interface/en.lproj/TDCServerPropertiesSheet.xib
+++ b/Sources/App/Resources/User Interface/en.lproj/TDCServerPropertiesSheet.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,7 +31,9 @@
                 <outlet property="clientCertificateSHA1FingerprintCopyButton" destination="f9F-WF-ubf" id="e62-bc-Pb2"/>
                 <outlet property="clientCertificateSHA1FingerprintField" destination="nFm-83-7HQ" id="8QY-ha-rQf"/>
                 <outlet property="clientCertificateSHA2FingerprintCopyButton" destination="758-2B-Ka3" id="zlF-cP-CFR"/>
-                <outlet property="clientCertificateSHA2FingerprintField" destination="2ie-9H-xb2" id="DRq-p4-jeL"/>
+                <outlet property="clientCertificateSHA2FingerprintField" destination="2ie-9H-xb2" id="D1L-7P-ktW"/>
+                <outlet property="clientCertificateSHA512FingerprintCopyButton" destination="YAo-Ly-Sf7" id="sHk-oB-HCl"/>
+                <outlet property="clientCertificateSHA512FingerprintField" destination="Ou1-Bl-kz1" id="V4S-rO-XS4"/>
                 <outlet property="connectCommandsField" destination="2310" id="2Ht-9D-ef5"/>
                 <outlet property="connectionDefaultddressTypeCheck" destination="zOI-7i-HTQ" id="atT-V9-DBS"/>
                 <outlet property="connectionIPv4AddressTypeCheck" destination="Doi-rA-9aF" id="wyV-Fd-Ii1"/>
@@ -104,7 +106,7 @@
         <window title="Server Properties" allowsToolTipsWhenApplicationIsInactive="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES"/>
             <rect key="contentRect" x="382" y="280" width="706" height="350"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3840" height="2160"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="706" height="350"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -113,7 +115,7 @@
                         <rect key="frame" x="10" y="10" width="156" height="330"/>
                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="c7A-uX-FoM">
                             <rect key="frame" x="1" y="1" width="154" height="328"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="19" rowSizeStyle="automatic" usesAutomaticRowHeights="YES" viewBased="YES" floatsGroupRows="NO" indentationPerLevel="15" outlineTableColumn="9ke-X4-49Z" id="Uj0-Wm-eox" customClass="TVCContentNavigationOutlineView">
                                     <rect key="frame" x="0.0" y="0.0" width="154" height="328"/>
@@ -135,9 +137,9 @@
                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView translatesAutoresizingMaskIntoConstraints="NO" id="yDz-eI-nqa">
-                                                    <rect key="frame" x="1" y="1" width="152" height="19"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="152" height="19"/>
                                                     <subviews>
-                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="L6D-B7-wWc">
+                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="L6D-B7-wWc">
                                                             <rect key="frame" x="0.0" y="2" width="152" height="15"/>
                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="VCb-YR-fs2">
                                                                 <font key="font" metaFont="cellTitle"/>
@@ -199,7 +201,7 @@ DQ
                     <box autoresizesSubviews="NO" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Uo7-GS-DCO">
                         <rect key="frame" x="173" y="36" width="526" height="306"/>
                         <view key="contentView" id="xFq-35-m2l">
-                            <rect key="frame" x="3" y="3" width="520" height="300"/>
+                            <rect key="frame" x="4" y="5" width="518" height="298"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         </view>
                     </box>
@@ -267,7 +269,7 @@ Gw
                     </columns>
                     <gridCells>
                         <gridCell row="uAb-uY-dJ9" column="4RY-Yh-h0w" id="vk7-v2-TLn">
-                            <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1538">
+                            <textField key="contentView" focusRingType="none" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1538">
                                 <rect key="frame" x="-2" y="112" width="117" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Connection Name:" id="1559">
                                     <font key="font" metaFont="system"/>
@@ -277,7 +279,7 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="uAb-uY-dJ9" column="kwW-4Q-r7S" id="xlG-iw-qu0">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1539" customClass="TVCValidatedTextField">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1539" customClass="TVCValidatedTextField">
                                 <rect key="frame" x="121" y="108" width="239" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="9j5-dY-0rN"/>
@@ -293,8 +295,8 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="hUK-uO-DWz" column="4RY-Yh-h0w" id="NPD-Vl-B1D">
-                            <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1540">
-                                <rect key="frame" x="-2" y="77" width="117" height="16"/>
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1540">
+                                <rect key="frame" x="-2" y="76" width="117" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Server Address:" id="1557">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -303,8 +305,8 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="hUK-uO-DWz" column="kwW-4Q-r7S" id="ZvZ-NZ-lR2">
-                            <comboBox key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1548" customClass="TVCValidatedComboBox">
-                                <rect key="frame" x="121" y="68" width="242" height="28"/>
+                            <comboBox key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1548" customClass="TVCValidatedComboBox">
+                                <rect key="frame" x="120" y="70" width="243" height="25"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="6ls-al-2Lu"/>
                                 </constraints>
@@ -319,7 +321,7 @@ Gw
                             </comboBox>
                         </gridCell>
                         <gridCell row="akK-h8-k22" column="4RY-Yh-h0w" id="Eny-p2-RoM">
-                            <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1542">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1542">
                                 <rect key="frame" x="-2" y="40" width="117" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Port:" id="1555">
                                     <font key="font" metaFont="system"/>
@@ -332,7 +334,7 @@ Gw
                             <stackView key="contentView" distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A6k-ee-dum">
                                 <rect key="frame" x="121" y="36" width="239" height="22"/>
                                 <subviews>
-                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1541" customClass="TVCValidatedTextField">
+                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1541" customClass="TVCValidatedTextField">
                                         <rect key="frame" x="0.0" y="0.0" width="60" height="22"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="60" id="PuT-pr-arX"/>
@@ -374,7 +376,7 @@ Gw
                             </stackView>
                         </gridCell>
                         <gridCell row="FhT-p4-Yz2" column="4RY-Yh-h0w" id="h1R-6C-hYu">
-                            <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1544">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1544">
                                 <rect key="frame" x="-2" y="4" width="117" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Server Password:" id="1553">
                                     <font key="font" metaFont="system"/>
@@ -384,7 +386,7 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="FhT-p4-Yz2" column="kwW-4Q-r7S" id="3cc-iU-xNw">
-                            <textField key="contentView" toolTip="Password to be sent using the PASS command. This is NOT your password for NickServ." verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1543" customClass="NSSecureTextField">
+                            <textField key="contentView" toolTip="Password to be sent using the PASS command. This is NOT your password for NickServ." focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1543" customClass="NSSecureTextField">
                                 <rect key="frame" x="121" y="0.0" width="239" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="KsP-sC-2yd"/>
@@ -490,7 +492,7 @@ Gw
                     </columns>
                     <gridCells>
                         <gridCell row="Zcw-cx-v0b" column="Lbn-2W-5bD" id="0yd-CU-QAD">
-                            <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1596">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1596">
                                 <rect key="frame" x="-2" y="76" width="144" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Nickname:" id="1618">
                                     <font key="font" metaFont="system"/>
@@ -500,7 +502,7 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="Zcw-cx-v0b" column="w3Z-Ld-gYr" id="CPp-os-0C3">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1595" customClass="TVCValidatedTextField">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1595" customClass="TVCValidatedTextField">
                                 <rect key="frame" x="148" y="72" width="212" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="8E0-IE-YRt"/>
@@ -517,7 +519,7 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="O4O-Ig-L5p" column="Lbn-2W-5bD" id="gAl-oa-fGd">
-                            <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2336">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2336">
                                 <rect key="frame" x="-2" y="40" width="144" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Away Nickname:" id="2341">
                                     <font key="font" metaFont="system"/>
@@ -527,7 +529,7 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="O4O-Ig-L5p" column="w3Z-Ld-gYr" id="kkb-Ih-JRo">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2335" customClass="TVCValidatedTextField">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2335" customClass="TVCValidatedTextField">
                                 <rect key="frame" x="148" y="36" width="212" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="zpG-Ug-YZW"/>
@@ -543,7 +545,7 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="H9A-aR-nQi" column="Lbn-2W-5bD" id="p1Q-6y-hrB">
-                            <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1603">
+                            <textField key="contentView" focusRingType="none" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1603">
                                 <rect key="frame" x="-2" y="4" width="144" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alternative Nicknames:" id="1611">
                                     <font key="font" metaFont="system"/>
@@ -553,7 +555,7 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="H9A-aR-nQi" column="w3Z-Ld-gYr" id="oh0-Rt-XDV">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1602" customClass="TVCValidatedTextField">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1602" customClass="TVCValidatedTextField">
                                 <rect key="frame" x="148" y="0.0" width="212" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="uTp-8Y-0uU"/>
@@ -570,7 +572,7 @@ Gw
                         </gridCell>
                     </gridCells>
                 </gridView>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1601" customClass="NSSecureTextField">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1601" customClass="NSSecureTextField">
                     <rect key="frame" x="228" y="98" width="212" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="gox-5X-KFr"/>
@@ -584,7 +586,7 @@ Gw
                         <accessibilityConnection property="title" destination="1623" id="9pE-K8-oT9"/>
                     </connections>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1623">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1623">
                     <rect key="frame" x="100" y="102" width="122" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Personal Password:" id="1626">
                         <font key="font" metaFont="system"/>
@@ -615,7 +617,7 @@ Gw
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="A3c-XH-Q30">
                     <rect key="frame" x="100" y="234" width="320" height="5"/>
                 </box>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1604">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1604">
                     <rect key="frame" x="226" y="249" width="166" height="15"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" title="This field is space separated" id="1610">
                         <font key="font" metaFont="cellTitle"/>
@@ -638,7 +640,7 @@ Gw
                     </columns>
                     <gridCells>
                         <gridCell row="hv7-1e-ySA" column="s8y-m2-ky8" id="ODW-v7-wHU">
-                            <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1598">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1598">
                                 <rect key="frame" x="-2" y="40" width="144" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="1616">
                                     <font key="font" metaFont="system"/>
@@ -648,7 +650,7 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="hv7-1e-ySA" column="UoC-5W-n5F" id="cWe-EP-PjO">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1597" customClass="TVCValidatedTextField">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1597" customClass="TVCValidatedTextField">
                                 <rect key="frame" x="148" y="36" width="212" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="uho-Mt-WUG"/>
@@ -664,7 +666,7 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="DVI-Kz-YNY" column="s8y-m2-ky8" id="8cf-Vq-00Y">
-                            <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1600">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1600">
                                 <rect key="frame" x="-2" y="4" width="144" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Real name:" id="1614">
                                     <font key="font" metaFont="system"/>
@@ -674,7 +676,7 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="DVI-Kz-YNY" column="UoC-5W-n5F" id="Rhp-1d-fOQ">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1599" customClass="TVCValidatedTextField">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1599" customClass="TVCValidatedTextField">
                                 <rect key="frame" x="148" y="0.0" width="212" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="nEL-Vg-sf4"/>
@@ -727,15 +729,15 @@ Gw
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="1627" userLabel="Messages View">
             <rect key="frame" x="0.0" y="0.0" width="520" height="300"/>
             <subviews>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1656">
-                    <rect key="frame" x="33" y="224" width="133" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1656">
+                    <rect key="frame" x="33" y="224" width="132" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Part &amp; Quit Message:" id="1668">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1671">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1671">
                     <rect key="frame" x="33" y="125" width="193" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Computer Sleep Quit Message:" id="1674">
                         <font key="font" metaFont="system"/>
@@ -743,7 +745,7 @@ Gw
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2290" customClass="TVCValidatedTextField">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2290" customClass="TVCValidatedTextField">
                     <rect key="frame" x="35" y="159" width="450" height="57"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="57" id="rHd-qc-Mnq"/>
@@ -757,7 +759,7 @@ Gw
                         <accessibilityConnection property="title" destination="1656" id="9XF-4w-7xl"/>
                     </connections>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2294" customClass="TVCValidatedTextField">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2294" customClass="TVCValidatedTextField">
                     <rect key="frame" x="35" y="60" width="450" height="57"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="57" id="cao-zF-kqD"/>
@@ -803,7 +805,7 @@ Gw
                     </columns>
                     <gridCells>
                         <gridCell row="HQO-PZ-kkO" column="x37-9J-r9J" id="ORJ-7a-we5">
-                            <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1687">
+                            <textField key="contentView" focusRingType="none" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1687">
                                 <rect key="frame" x="-2" y="35" width="65" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Encoding:" id="1690">
                                     <font key="font" metaFont="system"/>
@@ -826,7 +828,7 @@ Gw
                             </popUpButton>
                         </gridCell>
                         <gridCell row="ZX4-Aw-6qI" column="x37-9J-r9J" id="y4D-Wl-eCA">
-                            <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1686">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1686">
                                 <rect key="frame" x="-2" y="3" width="65" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Fallback:" id="1691">
                                     <font key="font" metaFont="system"/>
@@ -875,7 +877,7 @@ Gw
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="2542" userLabel="ZNC View">
             <rect key="frame" x="0.0" y="0.0" width="520" height="300"/>
             <subviews>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2590">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2590">
                     <rect key="frame" x="84" y="133" width="352" height="30"/>
                     <textFieldCell key="cell" selectable="YES" sendsActionOnEndEditing="YES" title="Do not show notification bubbles or play sounds for messages that are part of the playback buffer." id="2591">
                         <font key="font" metaFont="cellTitle"/>
@@ -907,7 +909,7 @@ Gw
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="JCf-aC-VgE">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="JCf-aC-VgE">
                     <rect key="frame" x="84" y="86" width="252" height="15"/>
                     <textFieldCell key="cell" selectable="YES" sendsActionOnEndEditing="YES" title="This option requires the “playback” module." id="DES-Fw-k4c">
                         <font key="font" metaFont="cellTitle"/>
@@ -922,10 +924,10 @@ Gw
                     <rect key="frame" x="35" y="238" width="450" height="31"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="Fx0-Yf-kbO">
                         <rect key="frame" x="0.0" y="0.0" width="450" height="31"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textView editable="NO" drawsBackground="NO" importsGraphics="NO" verticallyResizable="YES" allowsNonContiguousLayout="YES" id="ujo-Zq-Cf1">
-                                <rect key="frame" x="0.0" y="0.0" width="450" height="32"/>
+                                <rect key="frame" x="0.0" y="0.0" width="450" height="31"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -971,7 +973,7 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2599">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2599">
                     <rect key="frame" x="120" y="20" width="281" height="14"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" title="These options target version 1.2 of ZNC and later." id="2600">
                         <font key="font" metaFont="smallSystemBold"/>
@@ -1024,7 +1026,7 @@ Gw
                     <rect key="frame" x="54" y="54" width="412" height="220"/>
                     <clipView key="contentView" id="LcR-Dy-bmD">
                         <rect key="frame" x="1" y="1" width="410" height="218"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="Lh4-PC-UuF" id="1805" customClass="TVCBasicTableView">
                                 <rect key="frame" x="0.0" y="0.0" width="410" height="190"/>
@@ -1033,7 +1035,7 @@ Gw
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn identifier="name" editable="NO" width="248" minWidth="40" maxWidth="1000" id="1808">
+                                    <tableColumn identifier="name" editable="NO" width="219" minWidth="40" maxWidth="1000" id="1808">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Channel Name">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -1059,7 +1061,7 @@ Gw
                                         </textFieldCell>
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                     </tableColumn>
-                                    <tableColumn identifier="join" editable="NO" width="36.1845703125" minWidth="10" maxWidth="1000" id="1806">
+                                    <tableColumn identifier="join" editable="NO" width="36" minWidth="10" maxWidth="1000" id="1806">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Join">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -1096,14 +1098,14 @@ Gw
                 </scrollView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1794">
                     <rect key="frame" x="54" y="24" width="30" height="23"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="30" id="nWC-2d-INa"/>
-                        <constraint firstAttribute="height" constant="21" id="tD6-C7-slm"/>
-                    </constraints>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1801">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="30" id="nWC-2d-INa"/>
+                        <constraint firstAttribute="height" constant="21" id="tD6-C7-slm"/>
+                    </constraints>
                     <accessibility description="Add Channel"/>
                     <connections>
                         <action selector="addChannel:" target="-2" id="1815"/>
@@ -1111,14 +1113,14 @@ Gw
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1795">
                     <rect key="frame" x="416" y="24" width="50" height="23"/>
-                    <constraints>
-                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="KWH-oA-T2h"/>
-                        <constraint firstAttribute="height" constant="21" id="tgl-Uf-iCk"/>
-                    </constraints>
                     <buttonCell key="cell" type="smallSquare" title="Edit" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1800">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="KWH-oA-T2h"/>
+                        <constraint firstAttribute="height" constant="21" id="tgl-Uf-iCk"/>
+                    </constraints>
                     <accessibility description="Edit Selected Channel"/>
                     <connections>
                         <action selector="editChannel:" target="-2" id="1816"/>
@@ -1147,14 +1149,14 @@ Gw
             <subviews>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2449">
                     <rect key="frame" x="54" y="24" width="30" height="23"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="21" id="GCR-iJ-hff"/>
-                        <constraint firstAttribute="width" constant="30" id="iT9-DQ-Ye7"/>
-                    </constraints>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2461">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="21" id="GCR-iJ-hff"/>
+                        <constraint firstAttribute="width" constant="30" id="iT9-DQ-Ye7"/>
+                    </constraints>
                     <accessibility description="Add Highlight Match"/>
                     <connections>
                         <action selector="addHighlight:" target="-2" id="2481"/>
@@ -1175,7 +1177,7 @@ Gw
                     <rect key="frame" x="54" y="54" width="412" height="220"/>
                     <clipView key="contentView" id="txe-Gd-Uvj">
                         <rect key="frame" x="1" y="1" width="410" height="218"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="Gzo-0n-LCU" id="2454" customClass="TVCBasicTableView">
                                 <rect key="frame" x="0.0" y="0.0" width="410" height="190"/>
@@ -1184,7 +1186,7 @@ Gw
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn identifier="keyword" editable="NO" width="180.111083984375" minWidth="40" maxWidth="1000" id="2456">
+                                    <tableColumn identifier="keyword" editable="NO" width="151" minWidth="40" maxWidth="1000" id="2456">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Keyword">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -1197,7 +1199,7 @@ Gw
                                         </textFieldCell>
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                     </tableColumn>
-                                    <tableColumn identifier="type" editable="NO" width="79.5" minWidth="10" maxWidth="1000" id="2457" userLabel="Table Column - Entry Type">
+                                    <tableColumn identifier="type" editable="NO" width="80" minWidth="10" maxWidth="1000" id="2457" userLabel="Table Column - Entry Type">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Entry Type">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -1210,7 +1212,7 @@ Gw
                                         </textFieldCell>
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                     </tableColumn>
-                                    <tableColumn identifier="channel" editable="NO" width="131.7266845703125" minWidth="10" maxWidth="1000" id="2455">
+                                    <tableColumn identifier="channel" editable="NO" width="132" minWidth="10" maxWidth="1000" id="2455">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Channel">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -1248,14 +1250,14 @@ Gw
                 </scrollView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2448">
                     <rect key="frame" x="416" y="24" width="50" height="23"/>
-                    <constraints>
-                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="MuU-HJ-RlZ"/>
-                        <constraint firstAttribute="height" constant="21" id="TKi-UE-9Bc"/>
-                    </constraints>
                     <buttonCell key="cell" type="smallSquare" title="Edit" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2462">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="MuU-HJ-RlZ"/>
+                        <constraint firstAttribute="height" constant="21" id="TKi-UE-9Bc"/>
+                    </constraints>
                     <accessibility description="Edit Selected Highlight Match"/>
                     <connections>
                         <action selector="editHighlight:" target="-2" id="2482"/>
@@ -1282,7 +1284,7 @@ Gw
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="1817" userLabel="Ignores View">
             <rect key="frame" x="0.0" y="0.0" width="520" height="300"/>
             <subviews>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2358">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2358">
                     <rect key="frame" x="52" y="259" width="223" height="16"/>
                     <textFieldCell key="cell" selectable="YES" sendsActionOnEndEditing="YES" title="Ignore or track the following people:" id="2359">
                         <font key="font" metaFont="system"/>
@@ -1292,14 +1294,14 @@ Gw
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1843">
                     <rect key="frame" x="54" y="24" width="30" height="23"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="30" id="Z2m-Ok-I61"/>
-                        <constraint firstAttribute="height" constant="21" id="d1y-UR-sxL"/>
-                    </constraints>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1848">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="30" id="Z2m-Ok-I61"/>
+                        <constraint firstAttribute="height" constant="21" id="d1y-UR-sxL"/>
+                    </constraints>
                     <accessibility description="Add Address Book Entry"/>
                     <connections>
                         <action selector="showAddAddressBookEntryMenu:" target="-2" id="88b-Ti-Qfj"/>
@@ -1320,7 +1322,7 @@ Gw
                     <rect key="frame" x="54" y="54" width="412" height="197"/>
                     <clipView key="contentView" id="wXW-Pe-W5j">
                         <rect key="frame" x="1" y="1" width="410" height="195"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" headerView="NHj-wb-YWi" id="1851" customClass="TVCBasicTableView">
                                 <rect key="frame" x="0.0" y="0.0" width="410" height="167"/>
@@ -1329,7 +1331,7 @@ Gw
                                 <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn identifier="hostmask" editable="NO" width="299.313720703125" minWidth="40" maxWidth="1000" id="1853">
+                                    <tableColumn identifier="hostmask" editable="NO" width="299" minWidth="40" maxWidth="1000" id="1853">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Entry Mask">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.33333298560000002" alpha="1" colorSpace="calibratedWhite"/>
@@ -1342,7 +1344,7 @@ Gw
                                         </textFieldCell>
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                     </tableColumn>
-                                    <tableColumn identifier="type" width="95.5" minWidth="10" maxWidth="3.4028234663852886e+38" id="1982">
+                                    <tableColumn identifier="type" width="67" minWidth="10" maxWidth="3.4028234663852886e+38" id="1982">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Entry Type">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -1380,14 +1382,14 @@ Gw
                 </scrollView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1844">
                     <rect key="frame" x="416" y="24" width="50" height="23"/>
-                    <constraints>
-                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="3PF-wb-buW"/>
-                        <constraint firstAttribute="height" constant="21" id="Kwr-aI-8Mt"/>
-                    </constraints>
                     <buttonCell key="cell" type="smallSquare" title="Edit" bezelStyle="smallSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1847">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="3PF-wb-buW"/>
+                        <constraint firstAttribute="height" constant="21" id="Kwr-aI-8Mt"/>
+                    </constraints>
                     <accessibility description="Edit Selected Address Book Entry"/>
                     <connections>
                         <action selector="editAddressBookEntry:" target="-2" id="IB0-cr-GDM"/>
@@ -1424,7 +1426,7 @@ Gw
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="fNI-3k-yzt">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="fNI-3k-yzt">
                     <rect key="frame" x="313" y="254" width="152" height="15"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" alignment="right" title="This field is line separated" id="Mnf-Uj-ov2">
                         <font key="font" metaFont="cellTitle"/>
@@ -1438,15 +1440,15 @@ Gw
                 <scrollView focusRingType="exterior" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2309">
                     <rect key="frame" x="57" y="56" width="406" height="192"/>
                     <clipView key="contentView" drawsBackground="NO" id="rH8-fa-Y7i">
-                        <rect key="frame" x="1" y="1" width="404" height="190"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <rect key="frame" x="1" y="1" width="389" height="190"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" id="2310">
-                                <rect key="frame" x="0.0" y="0.0" width="404" height="190"/>
+                                <rect key="frame" x="0.0" y="0.0" width="389" height="190"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                <size key="minSize" width="404" height="190"/>
+                                <size key="minSize" width="389" height="190"/>
                                 <size key="maxSize" width="600" height="10000000"/>
                                 <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                             </textView>
@@ -1464,7 +1466,7 @@ Gw
                         <accessibilityConnection property="title" destination="1881" id="LJb-a8-u9c"/>
                     </connections>
                 </scrollView>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1881">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1881">
                     <rect key="frame" x="55" y="254" width="199" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" title="Perform commands on connect:" id="1882">
                         <font key="font" metaFont="system"/>
@@ -1509,7 +1511,7 @@ Gw
                             </columns>
                             <gridCells>
                                 <gridCell row="Wux-ui-Afe" column="UfM-t2-7vL" id="utt-iw-5Mt">
-                                    <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1897">
+                                    <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1897">
                                         <rect key="frame" x="-2" y="112" width="70" height="16"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Address:" id="1920">
                                             <font key="font" metaFont="system"/>
@@ -1519,7 +1521,7 @@ Gw
                                     </textField>
                                 </gridCell>
                                 <gridCell row="Wux-ui-Afe" column="GOB-Ox-jHY" id="Yfy-2w-str">
-                                    <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1901" customClass="TVCValidatedTextField">
+                                    <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1901" customClass="TVCValidatedTextField">
                                         <rect key="frame" x="74" y="108" width="246" height="22"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="22" id="CHb-rL-Cpx"/>
@@ -1535,7 +1537,7 @@ Gw
                                     </textField>
                                 </gridCell>
                                 <gridCell row="wAW-qX-GTz" column="UfM-t2-7vL" id="ECM-tm-H1X">
-                                    <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1898">
+                                    <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1898">
                                         <rect key="frame" x="-2" y="76" width="70" height="16"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Port:" id="1919">
                                             <font key="font" metaFont="system"/>
@@ -1548,7 +1550,7 @@ Gw
                                     <stackView key="contentView" distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fud-jH-umc">
                                         <rect key="frame" x="74" y="72" width="246" height="22"/>
                                         <subviews>
-                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="84A-gQ-HPC" customClass="TVCValidatedTextField">
+                                            <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="84A-gQ-HPC" customClass="TVCValidatedTextField">
                                                 <rect key="frame" x="0.0" y="0.0" width="60" height="22"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="22" id="3T9-ia-fvT"/>
@@ -1581,7 +1583,7 @@ Gw
                                     </stackView>
                                 </gridCell>
                                 <gridCell row="Onw-AC-h2l" column="UfM-t2-7vL" id="SPp-ui-RaR">
-                                    <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1900">
+                                    <textField key="contentView" focusRingType="none" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1900">
                                         <rect key="frame" x="-2" y="40" width="70" height="16"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Username:" id="1917">
                                             <font key="font" metaFont="system"/>
@@ -1591,7 +1593,7 @@ Gw
                                     </textField>
                                 </gridCell>
                                 <gridCell row="Onw-AC-h2l" column="GOB-Ox-jHY" id="RwZ-xF-727">
-                                    <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1904">
+                                    <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1904">
                                         <rect key="frame" x="74" y="36" width="246" height="22"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="22" id="jly-CJ-SHw"/>
@@ -1607,7 +1609,7 @@ Gw
                                     </textField>
                                 </gridCell>
                                 <gridCell row="cWB-GJ-DxE" column="UfM-t2-7vL" id="0Qw-1o-Faf">
-                                    <textField key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1899">
+                                    <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1899">
                                         <rect key="frame" x="-2" y="4" width="70" height="16"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="1918">
                                             <font key="font" metaFont="system"/>
@@ -1617,7 +1619,7 @@ Gw
                                     </textField>
                                 </gridCell>
                                 <gridCell row="cWB-GJ-DxE" column="GOB-Ox-jHY" id="e8B-zt-fSc">
-                                    <secureTextField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1902">
+                                    <secureTextField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1902">
                                         <rect key="frame" x="74" y="0.0" width="246" height="22"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="22" id="EPx-uC-UQ3"/>
@@ -1649,7 +1651,7 @@ Gw
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="yql-kd-PP5">
                     <rect key="frame" x="0.0" y="73" width="520" height="176"/>
                     <subviews>
-                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="P8N-qI-sG7">
+                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="P8N-qI-sG7">
                             <rect key="frame" x="78" y="76" width="364" height="48"/>
                             <textFieldCell key="cell" controlSize="mini" selectable="YES" sendsActionOnEndEditing="YES" id="voS-R3-3c7">
                                 <font key="font" metaFont="system"/>
@@ -1669,7 +1671,7 @@ Gw
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="GFp-Qd-4ck">
                     <rect key="frame" x="0.0" y="73" width="520" height="176"/>
                     <subviews>
-                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="fFG-yi-lT4">
+                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="fFG-yi-lT4">
                             <rect key="frame" x="78" y="86" width="364" height="48"/>
                             <textFieldCell key="cell" controlSize="mini" selectable="YES" sendsActionOnEndEditing="YES" id="R86-j6-hCz">
                                 <font key="font" metaFont="system"/>
@@ -1701,7 +1703,7 @@ Gw
                 <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Uxd-YG-qsq">
                     <rect key="frame" x="118" y="269" width="284" height="20"/>
                     <subviews>
-                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1896">
+                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1896">
                             <rect key="frame" x="-2" y="3" width="91" height="16"/>
                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Type of Proxy:" id="1921">
                                 <font key="font" metaFont="system"/>
@@ -1741,7 +1743,7 @@ Gw
                         <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1978">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1978">
                     <rect key="frame" x="211" y="249" width="236" height="15"/>
                     <textFieldCell key="cell" selectable="YES" sendsActionOnEndEditing="YES" title="This option requires a reconnect to apply" id="1979">
                         <font key="font" metaFont="cellTitle"/>
@@ -1753,7 +1755,7 @@ Gw
                     <rect key="frame" x="48" y="30" width="424" height="43"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="Of6-s1-mF9">
                         <rect key="frame" x="0.0" y="0.0" width="424" height="43"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textView editable="NO" drawsBackground="NO" importsGraphics="NO" verticallyResizable="YES" findStyle="panel" id="hIR-WT-lAK">
                                 <rect key="frame" x="0.0" y="42" width="424" height="43"/>
@@ -1854,7 +1856,7 @@ Gw
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="2078" userLabel="Flood Control">
             <rect key="frame" x="0.0" y="0.0" width="520" height="300"/>
             <subviews>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1gq-lL-Ur6">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1gq-lL-Ur6">
                     <rect key="frame" x="93" y="35" width="335" height="15"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" title="The options presented above require a reconnect to apply." id="MJ0-IQ-dNi">
                         <font key="font" metaFont="cellTitle"/>
@@ -1862,7 +1864,7 @@ Gw
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="CGo-eo-J2e">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="CGo-eo-J2e">
                     <rect key="frame" x="33" y="249" width="376" height="16"/>
                     <textFieldCell key="cell" selectable="YES" sendsActionOnEndEditing="YES" title="Do not send more than X number of commands in Y seconds." id="XQt-eN-ufQ">
                         <font key="font" metaFont="system"/>
@@ -1870,7 +1872,7 @@ Gw
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="rXs-B6-ItZ">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="rXs-B6-ItZ">
                     <rect key="frame" x="400" y="124" width="85" height="15"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" alignment="right" title="Current Value:" id="U5o-dB-jmW">
                         <font key="font" metaFont="cellTitle"/>
@@ -1885,7 +1887,7 @@ Gw
                         </binding>
                     </connections>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="w11-kJ-IPr">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="w11-kJ-IPr">
                     <rect key="frame" x="402" y="181" width="85" height="15"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" alignment="right" title="Current Value:" id="eMt-al-rqd">
                         <font key="font" metaFont="cellTitle"/>
@@ -1900,7 +1902,7 @@ Gw
                         </binding>
                     </connections>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Itb-Ee-5gX">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Itb-Ee-5gX">
                     <rect key="frame" x="45" y="124" width="142" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Y: Number of seconds:" id="Jay-s8-9Xn">
                         <font key="font" metaFont="system"/>
@@ -1911,7 +1913,7 @@ Gw
                 <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="7" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bJz-Am-LvT">
                     <rect key="frame" x="47" y="96" width="436" height="20"/>
                     <subviews>
-                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9b4-kF-7N0">
+                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9b4-kF-7N0">
                             <rect key="frame" x="-2" y="3" width="10" height="15"/>
                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="1" id="zP6-2E-iaW">
                                 <font key="font" metaFont="cellTitle"/>
@@ -1930,7 +1932,7 @@ Gw
                                 <binding destination="-2" name="value" keyPath="self.floodControlDelayTimerSliderTempValue" id="ICJ-8T-e2n"/>
                             </connections>
                         </slider>
-                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pDB-qm-dyE">
+                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pDB-qm-dyE">
                             <rect key="frame" x="418" y="3" width="20" height="15"/>
                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="60" id="9bE-uW-eqe">
                                 <font key="font" metaFont="cellTitle"/>
@@ -1953,7 +1955,7 @@ Gw
                 <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lqs-Qy-WoE">
                     <rect key="frame" x="47" y="153" width="438" height="20"/>
                     <subviews>
-                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kGJ-aW-aWu">
+                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kGJ-aW-aWu">
                             <rect key="frame" x="-2" y="3" width="10" height="15"/>
                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="1" id="ZNS-JS-fS4">
                                 <font key="font" metaFont="cellTitle"/>
@@ -1972,7 +1974,7 @@ Gw
                                 <binding destination="-2" name="value" keyPath="self.floodControlMessageCountSliderTempValue" id="5Wa-WZ-Qhz"/>
                             </connections>
                         </slider>
-                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sAt-Ob-XHX">
+                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sAt-Ob-XHX">
                             <rect key="frame" x="420" y="3" width="20" height="15"/>
                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="60" id="y5u-45-pvs">
                                 <font key="font" metaFont="cellTitle"/>
@@ -1992,7 +1994,7 @@ Gw
                         <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Af-cs-B5g">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Af-cs-B5g">
                     <rect key="frame" x="45" y="181" width="159" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="X: Number of commands:" id="jHb-Iz-2jU">
                         <font key="font" metaFont="system"/>
@@ -2070,7 +2072,7 @@ Gw
                         <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="46W-2g-sYj">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="46W-2g-sYj">
                     <rect key="frame" x="33" y="71" width="88" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Cipher suites:" id="Qfh-rz-IdC">
                         <font key="font" metaFont="system"/>
@@ -2097,7 +2099,7 @@ Gw
                     </connections>
                 </popUpButton>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BoR-WW-sT2">
-                    <rect key="frame" x="373" y="61" width="89" height="32"/>
+                    <rect key="frame" x="373" y="61" width="90" height="32"/>
                     <buttonCell key="cell" type="push" title="View List" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="LuK-ZI-qT9">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2106,7 +2108,7 @@ Gw
                         <action selector="preferredCipherSuitesViewList:" target="-2" id="UQs-lq-m95"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="T3E-ox-F6h">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="T3E-ox-F6h">
                     <rect key="frame" x="33" y="216" width="96" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Connect using:" id="B8q-jl-QtB">
                         <font key="font" metaFont="system"/>
@@ -2117,7 +2119,7 @@ Gw
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="XTj-LM-sfF">
                     <rect key="frame" x="135" y="216" width="272" height="16"/>
                     <subviews>
-                        <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Doi-rA-9aF">
+                        <button tag="1" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Doi-rA-9aF">
                             <rect key="frame" x="-2" y="-1" width="53" height="18"/>
                             <buttonCell key="cell" type="radio" title="IPv4" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="rrw-wu-OBL">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2127,7 +2129,7 @@ Gw
                                 <action selector="preferredInternetProtocolChanged:" target="-2" id="IdA-5M-B2J"/>
                             </connections>
                         </button>
-                        <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="dd4-fZ-E2b">
+                        <button tag="2" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dd4-fZ-E2b">
                             <rect key="frame" x="57" y="-1" width="53" height="18"/>
                             <buttonCell key="cell" type="radio" title="IPv6" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="PI4-um-V5J">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -2183,7 +2185,7 @@ Gw
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Ti4-Q4-cYX" userLabel="CertFP View">
             <rect key="frame" x="0.0" y="0.0" width="520" height="300"/>
             <subviews>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zU1-IR-zpt">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zU1-IR-zpt">
                     <rect key="frame" x="33" y="249" width="339" height="16"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Select a certificate to send when you connect securely." id="rIl-yx-VEH">
                         <font key="font" metaFont="system"/>
@@ -2227,22 +2229,23 @@ Gw
                     </customSpacing>
                 </stackView>
                 <gridView xPlacement="trailing" yPlacement="fill" rowAlignment="firstBaseline" rowSpacing="8" columnSpacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="GZe-xb-lrQ">
-                    <rect key="frame" x="20" y="90" width="480" height="120"/>
+                    <rect key="frame" x="20" y="76" width="480" height="148"/>
                     <rows>
                         <gridRow yPlacement="top" height="36" id="y0w-uO-wey"/>
+                        <gridRow id="LVM-ri-oUP"/>
                         <gridRow id="mRF-0R-krg"/>
                         <gridRow id="1CG-bD-ulB"/>
                         <gridRow id="DDA-TD-JgL"/>
                     </rows>
                     <columns>
-                        <gridColumn xPlacement="fill" id="mzu-pc-PbB"/>
+                        <gridColumn xPlacement="fill" width="137" id="mzu-pc-PbB"/>
                         <gridColumn xPlacement="fill" id="bSr-v0-1FE"/>
                         <gridColumn xPlacement="fill" id="70M-PD-rGb"/>
                     </columns>
                     <gridCells>
                         <gridCell row="y0w-uO-wey" column="mzu-pc-PbB" id="bNC-ND-dl8">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="vOo-Hg-7M0">
-                                <rect key="frame" x="-2" y="104" width="118" height="16"/>
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="vOo-Hg-7M0">
+                                <rect key="frame" x="-2" y="132" width="141" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Certificate Name:" usesSingleLineMode="YES" id="pxF-PC-Aax">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2251,8 +2254,8 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="y0w-uO-wey" column="bSr-v0-1FE" id="rAb-fO-YcL">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="nly-3d-FIq">
-                                <rect key="frame" x="120" y="104" width="302" height="16"/>
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="nly-3d-FIq">
+                                <rect key="frame" x="143" y="132" width="279" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" alignment="left" title="Label" usesSingleLineMode="YES" id="bvj-Qr-Ebk">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -2264,9 +2267,45 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="y0w-uO-wey" column="70M-PD-rGb" id="0lV-42-QBZ"/>
+                        <gridCell row="LVM-ri-oUP" column="mzu-pc-PbB" id="Pre-xR-cqo">
+                            <textField key="contentView" focusRingType="none" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eya-pw-9DN">
+                                <rect key="frame" x="-2" y="87" width="141" height="16"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="SHA-512 Fingerprint:" usesSingleLineMode="YES" id="dJe-xa-bmY">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </gridCell>
+                        <gridCell row="LVM-ri-oUP" column="bSr-v0-1FE" id="7JN-IO-EJT">
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ou1-Bl-kz1">
+                                <rect key="frame" x="143" y="87" width="279" height="16"/>
+                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" alignment="left" title="Label" usesSingleLineMode="YES" id="Cy6-oh-U2a">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <accessibilityConnection property="title" destination="eya-pw-9DN" id="SOi-tq-3BH"/>
+                                </connections>
+                            </textField>
+                        </gridCell>
+                        <gridCell row="LVM-ri-oUP" column="70M-PD-rGb" id="wXb-Te-bHe">
+                            <button key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YAo-Ly-Sf7">
+                                <rect key="frame" x="421" y="77" width="66" height="32"/>
+                                <buttonCell key="cell" type="push" title="Copy" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="305-Ff-AM7">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <accessibility description="Copy SHA-1 Fingerprint"/>
+                                <connections>
+                                    <action selector="onClientCertificateFingerprintSHA512CopyRequested:" target="-2" id="Vep-hQ-exc"/>
+                                </connections>
+                            </button>
+                        </gridCell>
                         <gridCell row="mRF-0R-krg" column="mzu-pc-PbB" id="fOI-GS-UCM">
-                            <textField key="contentView" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fdC-a6-iNA">
-                                <rect key="frame" x="-2" y="59" width="118" height="16"/>
+                            <textField key="contentView" focusRingType="none" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fdC-a6-iNA">
+                                <rect key="frame" x="-2" y="59" width="141" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="SHA-2 Fingerprint:" usesSingleLineMode="YES" id="jhF-Ix-th5">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2275,8 +2314,8 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="mRF-0R-krg" column="bSr-v0-1FE" id="QPa-gG-WYl">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2ie-9H-xb2">
-                                <rect key="frame" x="120" y="59" width="302" height="16"/>
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2ie-9H-xb2">
+                                <rect key="frame" x="143" y="59" width="279" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" alignment="left" title="Label" usesSingleLineMode="YES" id="Gbb-jh-4mY">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -2301,8 +2340,8 @@ Gw
                             </button>
                         </gridCell>
                         <gridCell row="1CG-bD-ulB" column="mzu-pc-PbB" id="IU7-Q5-HCF">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="h8M-bR-Uth">
-                                <rect key="frame" x="-2" y="31" width="118" height="16"/>
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="h8M-bR-Uth">
+                                <rect key="frame" x="-2" y="31" width="141" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="SHA-1 Fingerprint:" usesSingleLineMode="YES" id="O13-rx-ewF">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2311,8 +2350,8 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="1CG-bD-ulB" column="bSr-v0-1FE" id="04Y-ei-D2h">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="nFm-83-7HQ">
-                                <rect key="frame" x="120" y="31" width="302" height="16"/>
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="nFm-83-7HQ">
+                                <rect key="frame" x="143" y="31" width="279" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" alignment="left" title="Label" usesSingleLineMode="YES" id="Sia-Zk-rSR">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -2337,8 +2376,8 @@ Gw
                             </button>
                         </gridCell>
                         <gridCell row="DDA-TD-JgL" column="mzu-pc-PbB" id="Is8-DS-Eu3">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Fm4-76-q5h">
-                                <rect key="frame" x="-2" y="3" width="118" height="16"/>
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Fm4-76-q5h">
+                                <rect key="frame" x="-2" y="3" width="141" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="MD5 Fingerprint:" usesSingleLineMode="YES" id="Mmj-Ja-V8x">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2347,8 +2386,8 @@ Gw
                             </textField>
                         </gridCell>
                         <gridCell row="DDA-TD-JgL" column="bSr-v0-1FE" id="abJ-zN-WA0">
-                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Grr-p8-MOF">
-                                <rect key="frame" x="120" y="3" width="302" height="16"/>
+                            <textField key="contentView" focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Grr-p8-MOF">
+                                <rect key="frame" x="143" y="3" width="279" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" alignment="left" title="Label" usesSingleLineMode="YES" id="MCd-Ig-Szi">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -2408,7 +2447,7 @@ Gw
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="O3J-xl-nwg" userLabel="Redundancy">
             <rect key="frame" x="0.0" y="0.0" width="520" height="300"/>
             <subviews>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="I5e-l8-5t3">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="I5e-l8-5t3">
                     <rect key="frame" x="33" y="217" width="454" height="48"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="SnQ-4b-NG2">
                         <font key="font" metaFont="system"/>
@@ -2418,7 +2457,7 @@ Gw
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="InI-Fw-HoN">
-                    <rect key="frame" x="168" y="160" width="184" height="32"/>
+                    <rect key="frame" x="167" y="160" width="186" height="32"/>
                     <buttonCell key="cell" type="push" title="Modify Alternate Servers" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8N1-4l-slN">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -2437,13 +2476,21 @@ Gw
             </constraints>
             <point key="canvasLocation" x="582" y="6373"/>
         </customView>
-        <arrayController objectClassName="IRCAddressBookEntry" selectsInsertedObjects="NO" avoidsEmptySelection="NO" automaticallyRearrangesObjects="YES" id="aez-lt-zBV"/>
-        <arrayController objectClassName="IRCChannelConfig" selectsInsertedObjects="NO" avoidsEmptySelection="NO" clearsFilterPredicateOnInsertion="NO" automaticallyRearrangesObjects="YES" id="XlX-J4-ZJt"/>
-        <arrayController objectClassName="IRCHighlightMatchCondition" selectsInsertedObjects="NO" avoidsEmptySelection="NO" automaticallyRearrangesObjects="YES" id="XVW-tl-Aro"/>
-        <arrayController objectClassName="IRCServer" avoidsEmptySelection="NO" clearsFilterPredicateOnInsertion="NO" automaticallyRearrangesObjects="YES" id="Wea-hF-mxO"/>
+        <arrayController objectClassName="IRCAddressBookEntry" selectsInsertedObjects="NO" avoidsEmptySelection="NO" automaticallyRearrangesObjects="YES" id="aez-lt-zBV">
+            <classReference key="objectClass" className="IRCAddressBookEntry"/>
+        </arrayController>
+        <arrayController objectClassName="IRCChannelConfig" selectsInsertedObjects="NO" avoidsEmptySelection="NO" clearsFilterPredicateOnInsertion="NO" automaticallyRearrangesObjects="YES" id="XlX-J4-ZJt">
+            <classReference key="objectClass" className="IRCChannelConfig"/>
+        </arrayController>
+        <arrayController objectClassName="IRCHighlightMatchCondition" selectsInsertedObjects="NO" avoidsEmptySelection="NO" automaticallyRearrangesObjects="YES" id="XVW-tl-Aro">
+            <classReference key="objectClass" className="IRCHighlightMatchCondition"/>
+        </arrayController>
+        <arrayController objectClassName="IRCServer" avoidsEmptySelection="NO" clearsFilterPredicateOnInsertion="NO" automaticallyRearrangesObjects="YES" id="Wea-hF-mxO">
+            <classReference key="objectClass" className="IRCServer"/>
+        </arrayController>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="14" height="13"/>
-        <image name="NSRemoveTemplate" width="14" height="4"/>
+        <image name="NSAddTemplate" width="18" height="17"/>
+        <image name="NSRemoveTemplate" width="18" height="5"/>
     </resources>
 </document>


### PR DESCRIPTION
Allow users to copy the SHA-512 digest for their certificates, as suggested and used in /whois responses by [Liberchat](https://libera.chat/guides/certfp#add-your-fingerprint-to-nickserv).

Depends on https://github.com/Codeux-Software/Cocoa-Extensions/pull/2

The digest looks like this:

![Screenshot 2023-09-04 at 11 20 37 PM](https://github.com/Codeux-Software/Textual/assets/5462583/349815c4-0bc1-4366-aa3f-530bbc5b4ff3)

And I've confirmed that digest matches what Liberachat generates itself:

![Screenshot 2023-09-04 at 11 21 15 PM](https://github.com/Codeux-Software/Textual/assets/5462583/ac3a653a-6473-416a-b36d-c0dd6786698a)
