### PR TITLE
Add azzurra.chat network

### DIFF
--- a/Sources/App/Resources/Property Lists/IRCNetworks.plist
+++ b/Sources/App/Resources/Property Lists/IRCNetworks.plist
@@ -20,6 +20,15 @@
 		<key>prefersSecuredConnection</key>
 		<true/>
 	</dict>
+	<key>Azzurra</key>
+	<dict>
+		<key>serverAddress</key>
+		<string>irc.azzurra.chat</string>
+		<key>serverPort</key>
+		<integer>6697</integer>
+		<key>prefersSecuredConnection</key>
+		<true/>
+	</dict>
 	<key>DALnet</key>
 	<dict>
 		<key>serverAddress</key>


### PR DESCRIPTION
Context: Azzurra IRC Network is a long-running (since 1997) major Italian network. It had used the `azzurra.org` domain name since 2001, but it has been recently forced to renounce it due to the domain owner being uninvolved with network operations. On June 8th, the entire Azzurra network [transitioned to azzurra.chat](https://www.azzurra.chat/?mod=news) as the official domain name. The only link between the former name and the new one is a CNAME on `irc.azzurra.org`, which is only a temporary measure granted by the domain owner, and might not last long.

Since there is elevated risk of confusion among users, I suggest adding the network to default lists offered by clients, even if they didn't use to list Azzurra before. A number of online resources accumulated through the decades will point to the old hostname and won't be updated. Listing the network with the correct address might be a mitigation.

(Of course it's fair to disregard the request, but I still wish to document the transition)