### PR TITLE
Corrected misspelling of the word 'Maximum'

### DIFF
--- a/Sources/App/Resources/User Interface/en.lproj/TDCPreferences.xib
+++ b/Sources/App/Resources/User Interface/en.lproj/TDCPreferences.xib
@@ -4019,7 +4019,7 @@ A lower value is always better especially when in a large number of channels.</s
                                                                 </items>
                                                             </menu>
                                                         </popUpButtonCell>
-                                                        <accessibility description="Maxium File Size for Inline Images"/>
+                                                        <accessibility description="Maximum File Size for Inline Images"/>
                                                         <connections>
                                                             <binding destination="G2Q-fc-ddg" name="selectedTag" keyPath="values.InlineMediaMaximumFilesize" id="fxh-DZ-zVo"/>
                                                         </connections>


### PR DESCRIPTION
Just a simple correction of a spelling error:

Maxium -> Maximum