### PR TITLE
Fix compilation with License Manager disabled

### DIFF
--- a/Sources/App/Classes/Library/License Manager/Standalone/TLOLicenseManagerDownloader.m
+++ b/Sources/App/Classes/Library/License Manager/Standalone/TLOLicenseManagerDownloader.m
@@ -669,7 +669,11 @@ typedef void (^TLOLicenseManagerDownloaderConnectionCompletionBlock)(TLOLicenseM
 
 	NSString *applicationVersion = [TPCApplicationInfo applicationVersion].percentEncodedString;
 
+#if TEXTUAL_BUILT_WITH_LICENSE_MANAGER == 1
 	NSString *authorization = TLOLicenseManagerAuthorizationCode();
+#else
+	NSString *authorization = @"";
+#endif
 
 	NSString *requestBodyString = nil;
 


### PR DESCRIPTION
The `TLOLicenseManagerAuthorizationCode();` method is guarded within a preprocessor definition that checks whether `TEXTUAL_BUILT_WITH_LICENSE_MANAGER == 1` which means that if license manager is not included, the build will fail when trying to find that function.

I fixed that issue with this PR.